### PR TITLE
Add image assets

### DIFF
--- a/components/Dashboard.jsx
+++ b/components/Dashboard.jsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import flowImage from '../src/assets/ai_inference_flow.svg';
 
 const stats = [
   { label: 'AI Models', value: 52 },
@@ -37,15 +38,7 @@ const Dashboard = () => {
 
       <div className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">
         <h2 className="text-xl font-semibold mb-4">AI Inference Flow</h2>
-        <svg viewBox="0 0 600 100" className="w-full h-24">
-          <circle cx="50" cy="50" r="10" fill="#14ffe9" />
-          <line x1="60" y1="50" x2="200" y2="50" stroke="#14ffe9" strokeWidth="2" />
-          <circle cx="210" cy="50" r="20" fill="#14ffe9" />
-          <line x1="230" y1="50" x2="400" y2="30" stroke="#14ffe9" strokeWidth="2" />
-          <line x1="230" y1="50" x2="400" y2="70" stroke="#14ffe9" strokeWidth="2" />
-          <circle cx="400" cy="30" r="10" fill="#14ffe9" />
-          <circle cx="400" cy="70" r="10" fill="#14ffe9" />
-        </svg>
+        <img src={flowImage} alt="AI Inference Flow" className="w-full h-24 object-contain" />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { FaChartBar, FaRobot, FaBell, FaFileAlt, FaCog } from 'react-icons/fa';
+import logo from '../src/assets/auditmind_logo.svg';
 
 const Sidebar = () => {
   return (
     <aside className="w-64 bg-[#1a1f29] p-6 space-y-4">
-      <div className="text-2xl font-bold mb-8">AuditMind</div>
+      <img src={logo} alt="AuditMind logo" className="w-10 h-10 mb-8" />
       <nav className="flex flex-col space-y-4">
         <SidebarItem icon={<FaChartBar />} label="Dashboard" active />
         <SidebarItem icon={<FaRobot />} label="AI Models" />

--- a/src/assets/ai_inference_flow.svg
+++ b/src/assets/ai_inference_flow.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 600 120" xmlns="http://www.w3.org/2000/svg">
+  <!-- Input node -->
+  <circle cx="60" cy="60" r="25" fill="#14ffe9" />
+  <text x="60" y="65" font-size="12" text-anchor="middle" fill="#000">Input</text>
+
+  <!-- arrow -->
+  <line x1="85" y1="60" x2="160" y2="60" stroke="#14ffe9" stroke-width="3" marker-end="url(#arrowhead)" />
+
+  <!-- Model node -->
+  <circle cx="190" cy="60" r="35" fill="#14ffe9" />
+  <text x="190" y="65" font-size="12" text-anchor="middle" fill="#000">Model</text>
+
+  <!-- branching arrows -->
+  <line x1="225" y1="60" x2="300" y2="30" stroke="#14ffe9" stroke-width="3" marker-end="url(#arrowhead)" />
+  <line x1="225" y1="60" x2="300" y2="90" stroke="#14ffe9" stroke-width="3" marker-end="url(#arrowhead)" />
+
+  <!-- Output nodes -->
+  <circle cx="320" cy="30" r="20" fill="#14ffe9" />
+  <text x="320" y="35" font-size="12" text-anchor="middle" fill="#000">Out</text>
+
+  <circle cx="320" cy="90" r="20" fill="#14ffe9" />
+  <text x="320" y="95" font-size="12" text-anchor="middle" fill="#000">Out</text>
+
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#14ffe9" />
+    </marker>
+  </defs>
+</svg>

--- a/src/assets/auditmind_logo.svg
+++ b/src/assets/auditmind_logo.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" rx="20" fill="#14ffe9" />
+  <text x="50" y="55" font-size="50" font-family="Arial, Helvetica, sans-serif" text-anchor="middle" fill="#0e1116">A</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace static SVG in dashboard with imported asset
- show AuditMind logo in sidebar
- include new SVG assets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685555e894888327a31810ae2eef0507