### PR TITLE
Enhance dashboard with dynamic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ npm run dev
 - `Dashboard.jsx`: 주요 UI (KPI, SVG, Heatmap, Table)
 - `Sidebar.jsx`: 사이드바 구성
 - `Topbar.jsx`: 상단 탭
+
+### ✨ 최근 변경 사항
+- 상단바에서 업데이트 시간을 초 단위로 갱신합니다.
+- 대시보드 통계와 이벤트 로그가 5초마다 임의의 값으로 갱신되어 동적 화면을 시연합니다.

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,7 +1,7 @@
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
-const stats = [
+const initialStats = [
   { label: 'AI Models', value: 52 },
   { label: 'At Risk Models', value: 9, color: 'text-red-400' },
   { label: 'AI-Flagged Issues', value: 5478 },
@@ -17,13 +17,42 @@ const models = [
   { name: 'Model F', percent: '54%', status: 'High', color: 'text-red-500' },
 ];
 
-const events = [
+const initialEvents = [
   { time: '14:03', model: 'Model A', event: 'High Drift', diagnosed: 'AI', status: '82%' },
   { time: '13:58', model: 'Model B', event: 'Anomalous Input', diagnosed: 'AI Autaltide', status: '83%' },
   { time: '19:58', model: 'Model D', event: 'Data Drift', diagnosed: 'AI Automatb', status: '84%' },
 ];
 
 const Dashboard = () => {
+  const [stats, setStats] = useState(initialStats);
+  const [events, setEvents] = useState(initialEvents);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setStats((prev) =>
+        prev.map((s) => ({
+          ...s,
+          value:
+            typeof s.value === 'number'
+              ? s.value + Math.round(Math.random() * 2 - 1)
+              : s.value,
+        }))
+      );
+
+      setEvents((prev) => {
+        const newEvent = {
+          time: new Date().toLocaleTimeString().slice(0, 5),
+          model: 'Model X',
+          event: 'Automated Check',
+          diagnosed: 'System',
+          status: `${Math.floor(Math.random() * 10 + 90)}%`,
+        };
+        return [newEvent, ...prev.slice(0, 4)];
+      });
+    }, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <div className="space-y-10">
       <div className="grid grid-cols-2 md:grid-cols-4 gap-6">

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 const Topbar = () => {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsed((e) => e + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <div className="flex justify-between items-center p-4 border-b border-gray-700">
       <h1 className="text-2xl font-semibold">AI Risk Management Dashboard</h1>
       <div className="flex items-center gap-4">
-        <span className="text-sm text-gray-400">Updated 3s ago</span>
+        <span className="text-sm text-gray-400">Updated {elapsed}s ago</span>
         <button className="bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-2 rounded-lg font-medium">
           Download Report
         </button>


### PR DESCRIPTION
## Summary
- make update time on Topbar refresh every second
- refresh dashboard stats and event log every five seconds
- document dynamic behaviour in README

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855df142e8c8327ba51babee12d326b