### PR TITLE
Add real-time risk dashboard components

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,5 +1,8 @@
 
 import React, { useState, useEffect } from 'react';
+import RiskGauge from './RiskGauge';
+import ModelStatus from './ModelStatus';
+import Heatmap from './Heatmap';
 
 const initialStats = [
   { label: 'AI Models', value: 52 },
@@ -8,14 +11,6 @@ const initialStats = [
   { label: 'Data Drift Detected', value: 21 },
 ];
 
-const models = [
-  { name: 'Model A', percent: '52.5%', status: 'Active', color: 'text-cyan-400' },
-  { name: 'Model B', percent: '68%', status: 'AI Risk', color: 'text-yellow-400' },
-  { name: 'Model C', percent: '74%', status: 'Drift', color: 'text-orange-400' },
-  { name: 'Model D', percent: '58%', status: 'Aclotty', color: 'text-blue-400' },
-  { name: 'Model E', percent: '55%', status: 'AI Atleutt', color: 'text-red-400' },
-  { name: 'Model F', percent: '54%', status: 'High', color: 'text-red-500' },
-];
 
 const initialEvents = [
   { time: '14:03', model: 'Model A', event: 'High Drift', diagnosed: 'AI', status: '82%' },
@@ -71,31 +66,35 @@ const Dashboard = ({ onUpdate }) => {
 
       <div className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">
         <h2 className="text-xl font-semibold mb-4">AI Inference Flow</h2>
-        <svg viewBox="0 0 600 100" className="w-full h-24">
-          <circle cx="50" cy="50" r="10" fill="#14ffe9" />
-          <line x1="60" y1="50" x2="200" y2="50" stroke="#14ffe9" strokeWidth="2" />
-          <circle
-            cx="210"
-            cy="50"
-            r="20"
-            fill="#14ffe9"
-            className={highlight ? 'animate-ping' : ''}
-          />
-          <line x1="230" y1="50" x2="400" y2="30" stroke="#14ffe9" strokeWidth="2" />
-          <line x1="230" y1="50" x2="400" y2="70" stroke="#14ffe9" strokeWidth="2" />
-          <circle cx="400" cy="30" r="10" fill="#14ffe9" />
-          <circle cx="400" cy="70" r="10" fill="#14ffe9" />
-        </svg>
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+          <svg viewBox="0 0 600 100" className="w-full h-24 flex-1">
+            <circle cx="50" cy="50" r="10" fill="#14ffe9" />
+            <line x1="60" y1="50" x2="200" y2="50" stroke="#14ffe9" strokeWidth="2" />
+            <circle
+              cx="210"
+              cy="50"
+              r="20"
+              fill="#14ffe9"
+              className={highlight ? 'animate-ping' : ''}
+            />
+            <line x1="230" y1="50" x2="400" y2="30" stroke="#14ffe9" strokeWidth="2" />
+            <line x1="230" y1="50" x2="400" y2="70" stroke="#14ffe9" strokeWidth="2" />
+            <circle cx="400" cy="30" r="10" fill="#14ffe9" />
+            <circle cx="400" cy="70" r="10" fill="#14ffe9" />
+          </svg>
+          <RiskGauge />
+        </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {models.map((model, index) => (
-          <div key={index} className="bg-[#1a1f29] rounded-xl p-4 shadow">
-            <div className="text-sm text-gray-400">{model.name}</div>
-            <div className={`text-2xl font-bold ${model.color}`}>{model.percent}</div>
-            <div className="text-xs mt-1">{model.status}</div>
-          </div>
-        ))}
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="bg-[#1a1f29] rounded-xl p-6 shadow-lg flex flex-col items-center">
+          <h2 className="text-xl font-semibold mb-4">Risk Heatmap</h2>
+          <Heatmap />
+        </div>
+        <div className="flex flex-col justify-between">
+          <h2 className="text-xl font-semibold mb-4">Model Status</h2>
+          <ModelStatus />
+        </div>
       </div>
 
       <div className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">

--- a/src/components/Heatmap.jsx
+++ b/src/components/Heatmap.jsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from 'react';
+
+const generateCells = () =>
+  Array.from({ length: 25 }, () => Math.floor(Math.random() * 101));
+
+const getColor = (value) => {
+  if (value > 80) return 'bg-red-500';
+  if (value > 50) return 'bg-yellow-500';
+  return 'bg-blue-500';
+};
+
+const Heatmap = () => {
+  const [cells, setCells] = useState(generateCells());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCells(generateCells());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="grid grid-cols-5 gap-1 w-40 h-40">
+      {cells.map((v, i) => (
+        <div
+          key={i}
+          className={`w-full h-full ${getColor(v)} transition-colors`}
+          title={`${v}%`}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default Heatmap;

--- a/src/components/ModelStatus.jsx
+++ b/src/components/ModelStatus.jsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+
+const initialModels = [
+  { name: 'Model A', percent: 52.5, status: 'Active' },
+  { name: 'Model B', percent: 68, status: 'AI Risk' },
+  { name: 'Model C', percent: 74, status: 'Drift' },
+  { name: 'Model D', percent: 58, status: 'Audit' },
+  { name: 'Model E', percent: 55, status: 'AI Alert' },
+  { name: 'Model F', percent: 54, status: 'High' },
+];
+
+const getColor = (p) => {
+  if (p > 80) return 'text-red-500';
+  if (p > 60) return 'text-yellow-400';
+  return 'text-blue-400';
+};
+
+const ModelStatus = () => {
+  const [models, setModels] = useState(initialModels);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setModels((prev) =>
+        prev.map((m) => ({
+          ...m,
+          percent: Math.min(100, Math.max(0, m.percent + (Math.random() * 4 - 2))),
+        }))
+      );
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {models.map((model, i) => (
+        <div key={i} className="bg-[#1a1f29] rounded-xl p-4 shadow">
+          <div className="text-sm text-gray-400">{model.name}</div>
+          <div className={`text-2xl font-bold ${getColor(model.percent)}`}>{model.percent.toFixed(1)}%</div>
+          <div className="text-xs mt-1">{model.status}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ModelStatus;

--- a/src/components/RiskGauge.jsx
+++ b/src/components/RiskGauge.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+
+const getColor = (score) => {
+  if (score > 80) return 'text-red-500';
+  if (score > 50) return 'text-yellow-400';
+  return 'text-blue-400';
+};
+
+const RiskGauge = () => {
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setScore(Math.floor(Math.random() * 101));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative w-24 h-24">
+        <svg viewBox="0 0 36 36" className="w-full h-full rotate-[-90deg]">
+          <path
+            d="M18 2.0845
+              a 15.9155 15.9155 0 0 1 0 31.831
+              a 15.9155 15.9155 0 0 1 0 -31.831"
+            fill="none"
+            stroke="#2d3748"
+            strokeWidth="2"
+          />
+          <path
+            d="M18 2.0845
+              a 15.9155 15.9155 0 0 1 0 31.831"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeDasharray={`${score}, 100`}
+          />
+        </svg>
+        <div
+          className={`absolute inset-0 flex items-center justify-center text-xl font-bold ${getColor(score)}`}
+        >
+          {score}%
+        </div>
+      </div>
+      <span className={`mt-2 font-medium ${getColor(score)}`}>Risk Score</span>
+    </div>
+  );
+};
+
+export default RiskGauge;


### PR DESCRIPTION
## Summary
- add RiskGauge component to show live risk score
- add ModelStatus component that refreshes each model individually
- add Heatmap component for risk heat visualization
- integrate new components into Dashboard

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573c2a7da48327b70326581f16ecc7