### PR TITLE
Improve real-time dashboard visuals

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,32 +1,26 @@
 
 import React, { useState, useEffect } from 'react';
+import InferenceFlow from './InferenceFlow';
+import ModelStatus from './ModelStatus';
+import Heatmap from './Heatmap';
 
 const initialStats = [
-  { label: 'AI Models', value: 52 },
-  { label: 'At Risk Models', value: 9, color: 'text-red-400' },
-  { label: 'AI-Flagged Issues', value: 5478 },
-  { label: 'Data Drift Detected', value: 21 },
+  { label: 'AI Models', value: 52, bg: 'bg-blue-900', text: 'text-blue-200' },
+  { label: 'At Risk Models', value: 9, bg: 'bg-yellow-900', text: 'text-yellow-200' },
+  { label: 'Data Drift Detected', value: 21, bg: 'bg-red-900', text: 'text-red-200' },
 ];
 
-const models = [
-  { name: 'Model A', percent: '52.5%', status: 'Active', color: 'text-cyan-400' },
-  { name: 'Model B', percent: '68%', status: 'AI Risk', color: 'text-yellow-400' },
-  { name: 'Model C', percent: '74%', status: 'Drift', color: 'text-orange-400' },
-  { name: 'Model D', percent: '58%', status: 'Aclotty', color: 'text-blue-400' },
-  { name: 'Model E', percent: '55%', status: 'AI Atleutt', color: 'text-red-400' },
-  { name: 'Model F', percent: '54%', status: 'High', color: 'text-red-500' },
-];
 
 const initialEvents = [
-  { time: '14:03', model: 'Model A', event: 'High Drift', diagnosed: 'AI', status: '82%' },
-  { time: '13:58', model: 'Model B', event: 'Anomalous Input', diagnosed: 'AI Autaltide', status: '83%' },
-  { time: '19:58', model: 'Model D', event: 'Data Drift', diagnosed: 'AI Automatb', status: '84%' },
+  { time: '2:03 PM', model: 'Fraud Detector', event: 'High Drift', diagnosed: 'System Monitor', status: '82%' },
+  { time: '1:58 PM', model: 'Recommendation', event: 'Anomalous Input', diagnosed: 'Human Review', status: '83%' },
+  { time: '9:58 AM', model: 'Language Model', event: 'Data Drift', diagnosed: 'System Monitor', status: '84%' },
 ];
 
 const Dashboard = ({ onUpdate }) => {
   const [stats, setStats] = useState(initialStats);
   const [events, setEvents] = useState(initialEvents);
-  const [highlight, setHighlight] = useState(false);
+  const [rowPulse, setRowPulse] = useState(false);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -42,8 +36,12 @@ const Dashboard = ({ onUpdate }) => {
 
       setEvents((prev) => {
         const newEvent = {
-          time: new Date().toLocaleTimeString().slice(0, 5),
-          model: 'Model X',
+          time: new Date().toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          }),
+          model: 'Fraud Detector',
           event: 'Automated Check',
           diagnosed: 'System',
           status: `${Math.floor(Math.random() * 10 + 90)}%`,
@@ -51,8 +49,8 @@ const Dashboard = ({ onUpdate }) => {
         return [newEvent, ...prev.slice(0, 4)];
       });
 
-      setHighlight(true);
-      setTimeout(() => setHighlight(false), 500);
+      setRowPulse(true);
+      setTimeout(() => setRowPulse(false), 500);
       onUpdate && onUpdate();
     }, 1000);
     return () => clearInterval(interval);
@@ -60,42 +58,27 @@ const Dashboard = ({ onUpdate }) => {
 
   return (
     <div className="space-y-10">
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
         {stats.map((stat, index) => (
-          <div key={index} className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">
-            <div className={`text-3xl font-bold ${stat.color || 'text-white'}`}>{stat.value}</div>
-            <div className="text-sm text-gray-400 mt-1">{stat.label}</div>
+          <div key={index} className={`${stat.bg} rounded-xl p-6 shadow-lg`}>
+            <div className={`text-3xl font-bold ${stat.text}`}>{stat.value}</div>
+            <div className="text-sm text-gray-300 mt-1">{stat.label}</div>
           </div>
         ))}
+        <div className="bg-[#1a1f29] rounded-xl p-4 shadow-lg flex flex-col items-center justify-center">
+          <h2 className="text-sm font-semibold mb-2">Risk Heatmap</h2>
+          <Heatmap />
+        </div>
       </div>
 
       <div className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">
         <h2 className="text-xl font-semibold mb-4">AI Inference Flow</h2>
-        <svg viewBox="0 0 600 100" className="w-full h-24">
-          <circle cx="50" cy="50" r="10" fill="#14ffe9" />
-          <line x1="60" y1="50" x2="200" y2="50" stroke="#14ffe9" strokeWidth="2" />
-          <circle
-            cx="210"
-            cy="50"
-            r="20"
-            fill="#14ffe9"
-            className={highlight ? 'animate-ping' : ''}
-          />
-          <line x1="230" y1="50" x2="400" y2="30" stroke="#14ffe9" strokeWidth="2" />
-          <line x1="230" y1="50" x2="400" y2="70" stroke="#14ffe9" strokeWidth="2" />
-          <circle cx="400" cy="30" r="10" fill="#14ffe9" />
-          <circle cx="400" cy="70" r="10" fill="#14ffe9" />
-        </svg>
+        <InferenceFlow />
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {models.map((model, index) => (
-          <div key={index} className="bg-[#1a1f29] rounded-xl p-4 shadow">
-            <div className="text-sm text-gray-400">{model.name}</div>
-            <div className={`text-2xl font-bold ${model.color}`}>{model.percent}</div>
-            <div className="text-xs mt-1">{model.status}</div>
-          </div>
-        ))}
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Model Status</h2>
+        <ModelStatus />
       </div>
 
       <div className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">
@@ -112,7 +95,10 @@ const Dashboard = ({ onUpdate }) => {
           </thead>
           <tbody>
             {events.map((e, index) => (
-              <tr key={index} className="border-b border-gray-800">
+              <tr
+                key={index}
+                className={`border-b border-gray-800 ${index === 0 && rowPulse ? 'bg-gray-800' : ''}`}
+              >
                 <td className="py-2">{e.time}</td>
                 <td className="py-2">{e.model}</td>
                 <td className="py-2">{e.event}</td>

--- a/src/components/Heatmap.jsx
+++ b/src/components/Heatmap.jsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from 'react';
+
+const generateCells = () =>
+  Array.from({ length: 25 }, () => Math.floor(Math.random() * 101));
+
+const getColor = (value) => {
+  if (value > 80) return 'bg-red-500';
+  if (value > 50) return 'bg-yellow-500';
+  return 'bg-blue-500';
+};
+
+const Heatmap = () => {
+  const [cells, setCells] = useState(generateCells());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCells(generateCells());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="grid grid-cols-5 gap-1 w-40 h-40">
+      {cells.map((v, i) => (
+        <div
+          key={i}
+          className={`relative w-full h-full ${getColor(v)} flex items-center justify-center text-[10px] text-white transition-colors`}
+          title={`${v}%`}
+        >
+          {v}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Heatmap;

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import RiskGauge from './RiskGauge';
+
+const getColor = (score) => {
+  if (score > 80) return 'stroke-red-500';
+  if (score > 50) return 'stroke-yellow-400';
+  return 'stroke-blue-400';
+};
+
+const Sparkline = ({ data }) => {
+  const points = data
+    .map((v, i) => `${(i / (data.length - 1)) * 100},${100 - v}`)
+    .join(' ');
+  return (
+    <svg viewBox="0 0 100 100" className="w-32 h-16">
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        points={points}
+      />
+    </svg>
+  );
+};
+
+const InferenceFlow = () => {
+  const [history, setHistory] = useState([50]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setHistory((h) => {
+        const next = Math.floor(Math.random() * 101);
+        return [...h.slice(-19), next];
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const score = history[history.length - 1];
+
+  return (
+    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+      <svg viewBox="0 0 600 80" className={`w-full h-20 flex-1 ${getColor(score)}`}>
+        <defs>
+          <marker id="arrowhead" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          </marker>
+        </defs>
+        <style>{`#path1,#path2{stroke-dasharray:4;animation:dash 1s linear infinite;}@keyframes dash{to{stroke-dashoffset:-16;}}`}</style>
+        <rect x="10" y="25" width="80" height="30" rx="6" fill="currentColor" />
+        <text x="50" y="45" textAnchor="middle" fill="#0e1116" fontSize="12" fontWeight="bold">Input</text>
+        <line id="path1" x1="90" y1="40" x2="250" y2="40" stroke="currentColor" strokeWidth="2" markerEnd="url(#arrowhead)" />
+        <circle cx="300" cy="40" r="20" fill="currentColor" />
+        <text x="300" y="45" textAnchor="middle" fill="#0e1116" fontSize="12" fontWeight="bold">AI</text>
+        <line id="path2" x1="320" y1="40" x2="460" y2="40" stroke="currentColor" strokeWidth="2" markerEnd="url(#arrowhead)" />
+        <rect x="460" y="25" width="80" height="30" rx="6" fill="currentColor" />
+        <text x="500" y="45" textAnchor="middle" fill="#0e1116" fontSize="12" fontWeight="bold">Output</text>
+      </svg>
+      <div className="flex items-center gap-4">
+        <RiskGauge score={score} />
+        <Sparkline data={history} />
+      </div>
+    </div>
+  );
+};
+
+export default InferenceFlow;

--- a/src/components/ModelStatus.jsx
+++ b/src/components/ModelStatus.jsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+
+const initialModels = [
+  { name: 'Fraud Detector', percent: 92.1, status: 'Active' },
+  { name: 'Recommendation', percent: 76.4, status: 'Monitoring' },
+  { name: 'Anomaly Watch', percent: 61.3, status: 'Drift' },
+  { name: 'Language Model', percent: 84.7, status: 'Risk' },
+  { name: 'Vision Classifier', percent: 49.5, status: 'Active' },
+  { name: 'Forecast Engine', percent: 73.2, status: 'Audit' },
+];
+
+const getColor = (p) => {
+  if (p > 80) return 'text-red-500';
+  if (p > 60) return 'text-yellow-400';
+  return 'text-blue-400';
+};
+
+const ModelStatus = () => {
+  const [models, setModels] = useState(initialModels);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setModels((prev) =>
+        prev.map((m) => ({
+          ...m,
+          percent: Math.min(100, Math.max(0, m.percent + (Math.random() * 4 - 2))),
+        }))
+      );
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {models.map((model, i) => (
+        <div key={i} className="bg-[#1a1f29] rounded-xl p-4 shadow">
+          <div className="text-sm text-gray-400">{model.name}</div>
+          <div className={`text-2xl font-bold ${getColor(model.percent)}`}>{model.percent.toFixed(1)}%</div>
+          <div className="text-xs mt-1">{model.status}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ModelStatus;

--- a/src/components/RiskGauge.jsx
+++ b/src/components/RiskGauge.jsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+
+const getColor = (score) => {
+  if (score > 80) return 'text-red-500';
+  if (score > 50) return 'text-yellow-400';
+  return 'text-blue-400';
+};
+
+const RiskGauge = ({ score: external }) => {
+  const [score, setScore] = useState(external ?? 0);
+
+  useEffect(() => {
+    if (external === undefined) {
+      const interval = setInterval(() => {
+        setScore(Math.floor(Math.random() * 101));
+      }, 1000);
+      return () => clearInterval(interval);
+    }
+  }, [external]);
+
+  useEffect(() => {
+    if (external !== undefined) setScore(external);
+  }, [external]);
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative w-24 h-24">
+        <svg viewBox="0 0 36 36" className="w-full h-full rotate-[-90deg]">
+          <path
+            d="M18 2.0845
+              a 15.9155 15.9155 0 0 1 0 31.831
+              a 15.9155 15.9155 0 0 1 0 -31.831"
+            fill="none"
+            stroke="#2d3748"
+            strokeWidth="2"
+          />
+          <path
+            d="M18 2.0845
+              a 15.9155 15.9155 0 0 1 0 31.831"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeDasharray={`${score}, 100`}
+          />
+        </svg>
+        <div
+          className={`absolute inset-0 flex items-center justify-center text-xl font-bold ${getColor(score)}`}
+        >
+          {score}%
+        </div>
+      </div>
+      <span className={`mt-2 font-medium ${getColor(score)}`}>Risk Score</span>
+    </div>
+  );
+};
+
+export default RiskGauge;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -13,7 +13,16 @@ const items = [
 const Sidebar = ({ activeItem, onSelect }) => {
   return (
     <aside className="w-64 bg-[#1a1f29] p-6 space-y-4">
-      <div className="text-2xl font-bold mb-8">AuditMind</div>
+      <div className="flex items-center text-2xl font-bold mb-8">
+        <svg
+          className="w-8 h-8 text-blue-400 drop-shadow-lg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M12 2l9 20h-4l-2-5H9l-2 5H3l9-20z" />
+        </svg>
+        <span className="ml-2">AuditMind</span>
+      </div>
       <nav className="flex flex-col space-y-4">
         {items.map((item) => (
           <SidebarItem


### PR DESCRIPTION
## Summary
- refine KPI cards and add live risk heatmap beside them
- redesign AI Inference Flow arrows
- highlight incoming log rows
- modernize model list in ModelStatus
- insert glowing "A" logo in sidebar header
- overhaul AI Inference Flow with animated arrows and sparkline

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573c2a7da48327b70326581f16ecc7