### PR TITLE
Improve dynamic flows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,40 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Sidebar from './components/Sidebar';
 import Topbar from './components/Topbar';
 import Dashboard from './components/Dashboard';
+import AIModels from './components/AIModels';
+import RiskInsights from './components/RiskInsights';
+import AlertsPage from './components/AlertsPage';
+import ReportsPage from './components/ReportsPage';
+import SettingsPage from './components/SettingsPage';
 
 const App = () => {
+  const [active, setActive] = useState('Dashboard');
+
+  const renderPage = () => {
+    switch (active) {
+      case 'AI Models':
+        return <AIModels />;
+      case 'Risk Insights':
+        return <RiskInsights />;
+      case 'Alerts':
+        return <AlertsPage />;
+      case 'Reports':
+        return <ReportsPage />;
+      case 'Settings':
+        return <SettingsPage />;
+      default:
+        return <Dashboard />;
+    }
+  };
+
   return (
-    <div className="flex h-screen bg-[#0e1116] text-white">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
+    <div className="flex h-screen bg-[#131926] text-white">
+      <Sidebar activeItem={active} onSelect={setActive} />
+      <div className="flex-1 flex flex-col items-center">
         <Topbar />
-        <main className="p-6 overflow-y-auto">
-          <Dashboard />
+        <main className="p-6 overflow-y-auto w-full max-w-[1320px] mx-auto">
+          {renderPage()}
         </main>
       </div>
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import RiskInsights from './components/RiskInsights';
 import AlertsPage from './components/AlertsPage';
 import ReportsPage from './components/ReportsPage';
 import SettingsPage from './components/SettingsPage';
+import ARMPage from './components/ARMPage';
 
 const App = () => {
   const [active, setActive] = useState('Dashboard');
@@ -23,6 +24,8 @@ const App = () => {
         return <ReportsPage />;
       case 'Settings':
         return <SettingsPage />;
+      case 'ARM (AI Risk Manager)':
+        return <ARMPage />;
       default:
         return <Dashboard />;
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,12 @@ import RiskInsights from './components/RiskInsights';
 import AlertsPage from './components/AlertsPage';
 import ReportsPage from './components/ReportsPage';
 import SettingsPage from './components/SettingsPage';
-import ARMPage from './components/ARMPage';
+import APIMDashboard from './pages/api-manager/index';
+import APIRiskPage from './pages/api-manager/risk';
+import TrafficPage from './pages/api-manager/traffic';
+import TokenPage from './pages/api-manager/token';
+import PromptPage from './pages/api-manager/prompt';
+import SecurityPage from './pages/api-manager/security';
 
 const App = () => {
   const [active, setActive] = useState('Dashboard');
@@ -24,8 +29,18 @@ const App = () => {
         return <ReportsPage />;
       case 'Settings':
         return <SettingsPage />;
-      case 'ARM (AI Risk Manager)':
-        return <ARMPage />;
+      case 'API Manager Dashboard':
+        return <APIMDashboard />;
+      case 'API Manager API Risk':
+        return <APIRiskPage />;
+      case 'API Manager Traffic Guard':
+        return <TrafficPage />;
+      case 'API Manager Token Watch':
+        return <TokenPage />;
+      case 'API Manager Prompt Filter':
+        return <PromptPage />;
+      case 'API Manager Security Log':
+        return <SecurityPage />;
       default:
         return <Dashboard />;
     }

--- a/src/components/AIModels.jsx
+++ b/src/components/AIModels.jsx
@@ -1,11 +1,21 @@
 import React from 'react';
 import ModelStatus from './ModelStatus';
 
-const AIModels = () => (
-  <div className="p-6 space-y-4">
-    <h2 className="text-xl font-semibold mb-4">AI Models</h2>
-    <ModelStatus />
-  </div>
-);
+const AIModels = () => {
+  const [query, setQuery] = React.useState('');
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-semibold mb-4">AI Models</h2>
+      <input
+        className="w-full bg-[#171f2e] p-2 rounded text-sm mb-2"
+        placeholder="Search models"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <ModelStatus filter={query} />
+    </div>
+  );
+};
 
 export default AIModels;

--- a/src/components/AIModels.jsx
+++ b/src/components/AIModels.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ModelStatus from './ModelStatus';
+
+const AIModels = () => (
+  <div className="p-6 space-y-4">
+    <h2 className="text-xl font-semibold mb-4">AI Models</h2>
+    <ModelStatus />
+  </div>
+);
+
+export default AIModels;

--- a/src/components/APICallStatsCard.jsx
+++ b/src/components/APICallStatsCard.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export default function APICallStatsCard() {
+  const [stats, setStats] = useState({ calls: 0, errors: 0, latency: 0 });
+  useEffect(() => {
+    const id = setInterval(() => {
+      setStats({
+        calls: Math.floor(Math.random() * 10000),
+        errors: (Math.random() * 5).toFixed(2),
+        latency: Math.floor(Math.random() * 300),
+      });
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="bg-[#171f2e] p-4 rounded-lg shadow">
+      <div className="text-xl font-semibold mb-2">API Calls</div>
+      <div className="space-x-4">
+        <span>Total: {stats.calls}</span>
+        <span>Error Rate: {stats.errors}%</span>
+        <span>Avg Latency: {stats.latency}ms</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/APIErrorTable.jsx
+++ b/src/components/APIErrorTable.jsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export default function APIErrorTable() {
+  const [rows, setRows] = useState([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRows([
+        { code: 500, count: Math.floor(Math.random() * 10) },
+        { code: 404, count: Math.floor(Math.random() * 10) },
+        { code: 401, count: Math.floor(Math.random() * 10) },
+      ]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <table className="w-full bg-[#171f2e] rounded-lg p-4">
+      <thead><tr><th>Code</th><th>Count</th></tr></thead>
+      <tbody>
+        {rows.map(r => (
+          <tr key={r.code} className="text-center">
+            <td>{r.code}</td><td>{r.count}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/APIWatcher.jsx
+++ b/src/components/APIWatcher.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function APIWatcher() {
+  const stats = {
+    totalCalls: 5481,
+    errorRate: '2.4%',
+    avgLatency: '243ms',
+  };
+
+  return (
+    <div className="bg-slate-900 text-white rounded-lg p-4 shadow">
+      <h2 className="text-xl font-semibold mb-4">API 호출 리스크 요약</h2>
+      <div className="grid grid-cols-3 gap-4 text-sm">
+        <div>📊 총 호출 수: {stats.totalCalls}</div>
+        <div>⚠️ 오류율: {stats.errorRate}</div>
+        <div>⏱ 평균 응답시간: {stats.avgLatency}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ARMPage.jsx
+++ b/src/components/ARMPage.jsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from 'react';
+import APIWatcher from './APIWatcher';
+
+export default function ARMPage() {
+  const [refresh, setRefresh] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => setRefresh((r) => r + 1), 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="p-6 bg-slate-950 min-h-screen text-white space-y-6">
+      <h1 className="text-3xl font-bold">🛡️ API Risk Manager</h1>
+      <APIWatcher key={`api-${refresh}`} />
+    </div>
+  );
+}

--- a/src/components/AlertHub.jsx
+++ b/src/components/AlertHub.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function AlertHub() {
+  const [alerts, setAlerts] = useState([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setAlerts((a) => [
+        ...a.slice(-4),
+        { msg: 'Error rate high', time: new Date().toLocaleTimeString() },
+      ]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="bg-[#171f2e] p-4 rounded-lg">
+      <div className="font-semibold mb-2">Alerts</div>
+      <ul className="space-y-1">
+        {alerts.map((al, i) => (
+          <li key={i} className="text-sm">[{al.time}] {al.msg}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/AlertsPage.jsx
+++ b/src/components/AlertsPage.jsx
@@ -1,0 +1,55 @@
+import React, { useState, useEffect } from 'react';
+
+const AlertsPage = () => {
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setEvents((prev) => {
+        const models = ['Fraud Detector', 'Recommendation', 'Language Model'];
+        const events = ['Anomaly', 'Drift', 'Spike'];
+        const diagnosers = ['System', 'Auto Audit', 'Analyst'];
+        const newEvent = {
+          time: new Date().toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          }),
+          model: models[Math.floor(Math.random() * models.length)],
+          event: events[Math.floor(Math.random() * events.length)],
+          diagnosed: diagnosers[Math.floor(Math.random() * diagnosers.length)],
+        };
+        return [newEvent, ...prev.slice(0, 9)];
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-semibold mb-4">Alerts</h2>
+      <table className="w-full text-sm">
+        <thead className="text-gray-400 border-b border-gray-700">
+          <tr>
+            <th className="py-2 text-left">Time</th>
+            <th className="py-2 text-left">Model</th>
+            <th className="py-2 text-left">Event</th>
+            <th className="py-2 text-left">Diagnosed By</th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map((e, i) => (
+            <tr key={i} className="border-b border-gray-800 hover:bg-[#1e2536]">
+              <td className="py-2">{e.time}</td>
+              <td className="py-2">{e.model}</td>
+              <td className="py-2">{e.event}</td>
+              <td className="py-2">{e.diagnosed}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default AlertsPage;

--- a/src/components/AlertsPage.jsx
+++ b/src/components/AlertsPage.jsx
@@ -18,6 +18,7 @@ const AlertsPage = () => {
           model: models[Math.floor(Math.random() * models.length)],
           event: events[Math.floor(Math.random() * events.length)],
           diagnosed: diagnosers[Math.floor(Math.random() * diagnosers.length)],
+          resolved: false,
         };
         return [newEvent, ...prev.slice(0, 9)];
       });
@@ -43,7 +44,23 @@ const AlertsPage = () => {
               <td className="py-2">{e.time}</td>
               <td className="py-2">{e.model}</td>
               <td className="py-2">{e.event}</td>
-              <td className="py-2">{e.diagnosed}</td>
+              <td className="py-2 flex items-center gap-2">
+                {e.diagnosed}
+                {!e.resolved && (
+                  <button
+                    onClick={() =>
+                      setEvents((prev) =>
+                        prev.map((ev, idx) =>
+                          idx === i ? { ...ev, resolved: true } : ev
+                        )
+                      )
+                    }
+                    className="text-xs px-2 py-1 rounded bg-[#34b4ff] text-white"
+                  >
+                    Resolve
+                  </button>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/src/components/BlockedClientsList.jsx
+++ b/src/components/BlockedClientsList.jsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export default function BlockedClientsList() {
+  const [clients, setClients] = useState([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setClients(['192.168.0.1', '10.0.0.2'].slice(0, Math.floor(Math.random()*2)+1));
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="bg-[#171f2e] p-4 rounded-lg">
+      <div className="font-semibold mb-2">Blocked Clients</div>
+      <ul className="list-disc list-inside text-sm">
+        {clients.map(c => <li key={c}>{c}</li>)}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/DangerScoreCard.jsx
+++ b/src/components/DangerScoreCard.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const DangerScoreCard = ({ score, state }) => (
+  <div
+    className="flex flex-col items-center justify-center text-center bg-[#262e3e] rounded-lg"
+    style={{ width: 72, height: 48, boxShadow: '0 0 12px rgba(255,90,71,0.6)', animation: 'heart 1.2s infinite' }}
+  >
+    <div className="text-[2.2rem] font-bold leading-none" style={{ color: '#ff5a47' }}>
+      {score}
+    </div>
+    <div className="text-xs text-[#a2acc9] mt-1">{state}</div>
+    <style>{`
+      @keyframes heart { 0%{transform:scale(1);}50%{transform:scale(1.05);}100%{transform:scale(1);} }
+    `}</style>
+  </div>
+);
+
+export default DangerScoreCard;

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -23,6 +23,10 @@ const Dashboard = ({ onUpdate }) => {
   const [events, setEvents] = useState(initialEvents);
   const [rowPulse, setRowPulse] = useState(false);
 
+  const addEvent = (evt) => {
+    setEvents((prev) => [evt, ...prev.slice(0, 4)]);
+  };
+
   useEffect(() => {
     const interval = setInterval(() => {
       setStats((prev) =>
@@ -87,7 +91,7 @@ const Dashboard = ({ onUpdate }) => {
 
       <div className="bg-[#171f2e] rounded-xl p-4" style={{ boxShadow: '0 2px 16px rgba(22,28,38,0.4)' }}>
         <h2 className="text-lg font-semibold mb-3">AI Inference Flow</h2>
-        <InferenceFlow />
+        <InferenceFlow onAlert={addEvent} />
       </div>
 
       <div>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -5,9 +5,10 @@ import ModelStatus from './ModelStatus';
 import Heatmap from './Heatmap';
 
 const initialStats = [
-  { label: 'AI Models', value: 52, color: '#ffffff' },
-  { label: 'At Risk Models', value: 9, color: '#ff5a47' },
-  { label: 'AI-Flagged Issues', value: 5478, color: '#ffffff' },
+  { label: 'AI Models', key: 'models', value: 52, color: '#ffffff' },
+  { label: 'At Risk Models', key: 'atRisk', value: 9, color: '#ff5a47' },
+  { label: 'AI-Flagged Issues', key: 'flaggedIssues', value: 5478, color: '#ffffff' },
+  { label: 'Data Drift Detected', key: 'dataDrift', value: 21, color: '#ffffff' },
 ];
 
 
@@ -61,7 +62,7 @@ const Dashboard = ({ onUpdate }) => {
 
   return (
     <div className="space-y-8">
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
         {stats.map((stat, index) => (
           <div
             key={index}

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,32 +1,26 @@
 
 import React, { useState, useEffect } from 'react';
+import InferenceFlow from './InferenceFlow';
+import ModelStatus from './ModelStatus';
+import Heatmap from './Heatmap';
 
 const initialStats = [
-  { label: 'AI Models', value: 52 },
-  { label: 'At Risk Models', value: 9, color: 'text-red-400' },
-  { label: 'AI-Flagged Issues', value: 5478 },
-  { label: 'Data Drift Detected', value: 21 },
+  { label: 'AI Models', value: 52, color: '#ffffff' },
+  { label: 'At Risk Models', value: 9, color: '#ff5a47' },
+  { label: 'AI-Flagged Issues', value: 5478, color: '#ffffff' },
 ];
 
-const models = [
-  { name: 'Model A', percent: '52.5%', status: 'Active', color: 'text-cyan-400' },
-  { name: 'Model B', percent: '68%', status: 'AI Risk', color: 'text-yellow-400' },
-  { name: 'Model C', percent: '74%', status: 'Drift', color: 'text-orange-400' },
-  { name: 'Model D', percent: '58%', status: 'Aclotty', color: 'text-blue-400' },
-  { name: 'Model E', percent: '55%', status: 'AI Atleutt', color: 'text-red-400' },
-  { name: 'Model F', percent: '54%', status: 'High', color: 'text-red-500' },
-];
 
 const initialEvents = [
-  { time: '14:03', model: 'Model A', event: 'High Drift', diagnosed: 'AI', status: '82%' },
-  { time: '13:58', model: 'Model B', event: 'Anomalous Input', diagnosed: 'AI Autaltide', status: '83%' },
-  { time: '19:58', model: 'Model D', event: 'Data Drift', diagnosed: 'AI Automatb', status: '84%' },
+  { time: '10:12 AM', model: 'Fraud Detector', event: 'Drift Detected', diagnosed: 'System Monitor', status: '91%' },
+  { time: '9:05 AM', model: 'Recommendation', event: 'Spike in Traffic', diagnosed: 'Auto Audit', status: '87%' },
+  { time: '8:43 AM', model: 'Language Model', event: 'High Risk', diagnosed: 'Human Analyst', status: '89%' },
 ];
 
 const Dashboard = ({ onUpdate }) => {
   const [stats, setStats] = useState(initialStats);
   const [events, setEvents] = useState(initialEvents);
-  const [highlight, setHighlight] = useState(false);
+  const [rowPulse, setRowPulse] = useState(false);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -41,64 +35,66 @@ const Dashboard = ({ onUpdate }) => {
       );
 
       setEvents((prev) => {
+        const models = ['Fraud Detector', 'Recommendation', 'Language Model'];
+        const events = ['Automated Check', 'Data Drift', 'Spike'];
+        const diagnosers = ['System Monitor', 'Auto Audit', 'Human Analyst'];
         const newEvent = {
-          time: new Date().toLocaleTimeString().slice(0, 5),
-          model: 'Model X',
-          event: 'Automated Check',
-          diagnosed: 'System',
+          time: new Date().toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          }),
+          model: models[Math.floor(Math.random() * models.length)],
+          event: events[Math.floor(Math.random() * events.length)],
+          diagnosed: diagnosers[Math.floor(Math.random() * diagnosers.length)],
           status: `${Math.floor(Math.random() * 10 + 90)}%`,
         };
         return [newEvent, ...prev.slice(0, 4)];
       });
 
-      setHighlight(true);
-      setTimeout(() => setHighlight(false), 500);
+      setRowPulse(true);
+      setTimeout(() => setRowPulse(false), 500);
       onUpdate && onUpdate();
     }, 1000);
     return () => clearInterval(interval);
   }, [onUpdate]);
 
   return (
-    <div className="space-y-10">
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+    <div className="space-y-8">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         {stats.map((stat, index) => (
-          <div key={index} className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">
-            <div className={`text-3xl font-bold ${stat.color || 'text-white'}`}>{stat.value}</div>
-            <div className="text-sm text-gray-400 mt-1">{stat.label}</div>
+          <div
+            key={index}
+            className="bg-[#171f2e] rounded-xl p-3 flex flex-col justify-between"
+            style={{ width: 180, height: 70, boxShadow: '0 2px 16px rgba(22,28,38,0.4)' }}
+          >
+            <div className="text-[2.1rem] font-bold" style={{ color: stat.color }}>
+              {stat.value}
+            </div>
+            <div className="text-[1.03rem] font-semibold" style={{ color: '#a2acc9' }}>
+              {stat.label}
+            </div>
           </div>
         ))}
+        <div
+          className="bg-[#171f2e] rounded-xl p-3 flex flex-col"
+          style={{ width: 180, boxShadow: '0 2px 16px rgba(22,28,38,0.4)' }}
+        >
+          <Heatmap />
+        </div>
       </div>
 
-      <div className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">
-        <h2 className="text-xl font-semibold mb-4">AI Inference Flow</h2>
-        <svg viewBox="0 0 600 100" className="w-full h-24">
-          <circle cx="50" cy="50" r="10" fill="#14ffe9" />
-          <line x1="60" y1="50" x2="200" y2="50" stroke="#14ffe9" strokeWidth="2" />
-          <circle
-            cx="210"
-            cy="50"
-            r="20"
-            fill="#14ffe9"
-            className={highlight ? 'animate-ping' : ''}
-          />
-          <line x1="230" y1="50" x2="400" y2="30" stroke="#14ffe9" strokeWidth="2" />
-          <line x1="230" y1="50" x2="400" y2="70" stroke="#14ffe9" strokeWidth="2" />
-          <circle cx="400" cy="30" r="10" fill="#14ffe9" />
-          <circle cx="400" cy="70" r="10" fill="#14ffe9" />
-        </svg>
+      <div className="bg-[#171f2e] rounded-xl p-4" style={{ boxShadow: '0 2px 16px rgba(22,28,38,0.4)' }}>
+        <h2 className="text-lg font-semibold mb-3">AI Inference Flow</h2>
+        <InferenceFlow />
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        {models.map((model, index) => (
-          <div key={index} className="bg-[#1a1f29] rounded-xl p-4 shadow">
-            <div className="text-sm text-gray-400">{model.name}</div>
-            <div className={`text-2xl font-bold ${model.color}`}>{model.percent}</div>
-            <div className="text-xs mt-1">{model.status}</div>
-          </div>
-        ))}
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Model Status</h2>
+        <ModelStatus />
       </div>
 
-      <div className="bg-[#1a1f29] rounded-xl p-6 shadow-lg">
+      <div className="bg-[#171f2e] rounded-xl p-6" style={{ boxShadow: '0 2px 16px rgba(22,28,38,0.4)' }}>
         <h2 className="text-xl font-semibold mb-4">Event Log</h2>
         <table className="w-full text-sm">
           <thead className="text-gray-400 border-b border-gray-700">
@@ -112,7 +108,10 @@ const Dashboard = ({ onUpdate }) => {
           </thead>
           <tbody>
             {events.map((e, index) => (
-              <tr key={index} className="border-b border-gray-800">
+              <tr
+                key={index}
+                className={`border-b border-gray-800 transition-colors hover:bg-[#1e2536] ${index === 0 && rowPulse ? 'bg-[#1e2536]' : ''}`}
+              >
                 <td className="py-2">{e.time}</td>
                 <td className="py-2">{e.model}</td>
                 <td className="py-2">{e.event}</td>

--- a/src/components/FlowCurve.jsx
+++ b/src/components/FlowCurve.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const FlowCurve = ({ d, color = 'url(#emerald)', width = 3, marker = '' }) => (
+  <path
+    d={d}
+    stroke={color}
+    strokeWidth={width}
+    fill="none"
+    strokeDasharray="13 10"
+    markerEnd={marker}
+    className="flow-curve"
+  />
+);
+
+export default FlowCurve;

--- a/src/components/FlowCurve.jsx
+++ b/src/components/FlowCurve.jsx
@@ -1,13 +1,21 @@
 import React from 'react';
 
-const FlowCurve = ({ d, color = 'url(#emerald)', width = 3, marker = '' }) => (
+const FlowCurve = ({
+  d,
+  color = 'url(#emerald)',
+  width = 3,
+  markerStart = '',
+  markerEnd = '',
+  dash = '13 10',
+}) => (
   <path
     d={d}
     stroke={color}
     strokeWidth={width}
     fill="none"
-    strokeDasharray="13 10"
-    markerEnd={marker}
+    strokeDasharray={dash}
+    markerStart={markerStart}
+    markerEnd={markerEnd}
     className="flow-curve"
   />
 );

--- a/src/components/Heatmap.jsx
+++ b/src/components/Heatmap.jsx
@@ -56,12 +56,15 @@ const Heatmap = () => {
   return (
     <div className="text-white font-[Pretendard,sans-serif]">
       <div className="flex justify-between items-center mb-2 text-sm font-bold">
-        <span>실시간 AI 리스크 히트맵</span>
+        <div className="leading-tight">
+          <div>AI Risk</div>
+          <div>HeatMap</div>
+        </div>
         <span className="text-[#a2acc9] text-[0.85rem]">Updated: {lastUpdate}</span>
       </div>
       <div
         className="grid grid-cols-5"
-        style={{ width: 140, height: 140, gap: 4 }}
+        style={{ width: 150, height: 150, gap: 4 }}
       >
         {cells.map((cell, i) => (
           <div

--- a/src/components/Heatmap.jsx
+++ b/src/components/Heatmap.jsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react';
+
+const names = Array.from({ length: 25 }, (_, i) => `Model${i + 1}`);
+
+const generateCells = () =>
+  names.map((name) => ({
+    name,
+    value: Math.floor(Math.random() * 101),
+    updated: new Date().toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    }),
+  }));
+
+const getColor = (value) => {
+  if (value > 80) return '#ff5a47';
+  if (value > 50) return '#54a7f8';
+  return '#233a56';
+};
+
+const Heatmap = () => {
+  const [cells, setCells] = useState(generateCells());
+  const [selected, setSelected] = useState(null);
+  const [lastUpdate, setLastUpdate] = useState(() =>
+    new Date().toLocaleTimeString('en-US', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCells(generateCells());
+      setLastUpdate(
+        new Date().toLocaleTimeString('en-US', {
+          hour12: false,
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        })
+      );
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const openDetail = (cell) => {
+    setSelected(cell);
+  };
+
+  const closeDetail = () => setSelected(null);
+
+  return (
+    <div className="text-white font-[Pretendard,sans-serif]">
+      <div className="flex justify-between items-center mb-2 text-sm font-bold">
+        <span>실시간 AI 리스크 히트맵</span>
+        <span className="text-[#a2acc9] text-[0.85rem]">Updated: {lastUpdate}</span>
+      </div>
+      <div
+        className="grid grid-cols-5"
+        style={{ width: 140, height: 140, gap: 4 }}
+      >
+        {cells.map((cell, i) => (
+          <div
+            key={cell.name}
+            onClick={() => openDetail(cell)}
+            className="relative flex items-center justify-center text-[10px] font-medium transition-colors"
+            style={{
+              width: 26,
+              height: 26,
+              backgroundColor: getColor(cell.value),
+              transitionProperty: 'background',
+              transitionDuration: '0.2s',
+              outline: 'none',
+              cursor: 'pointer',
+              borderRadius: 6,
+            }}
+            title={`${cell.name} ${cell.value} @${cell.updated}`}
+            onMouseEnter={(e) => (e.currentTarget.style.outline = '#54a7f8 2px solid')}
+            onMouseLeave={(e) => (e.currentTarget.style.outline = 'none')}
+          >
+            {cell.value}
+            {selected?.name === cell.name && (
+              <div
+                className="absolute inset-0 bg-white/20 rounded pointer-events-none"
+                style={{ backdropFilter: 'blur(2px)' }}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      {selected && (
+        <div
+          className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+          onClick={closeDetail}
+        >
+          <div className="bg-[#171f2e] rounded-xl p-6" style={{ minWidth: 200 }}>
+            <h3 className="text-lg font-semibold mb-2">{selected.name}</h3>
+            <p>Value: {selected.value}</p>
+            <p>Updated: {selected.updated}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Heatmap;

--- a/src/components/Heatmap.jsx
+++ b/src/components/Heatmap.jsx
@@ -15,8 +15,8 @@ const generateCells = () =>
   }));
 
 const getColor = (value) => {
-  if (value > 80) return '#ff5a47';
-  if (value > 50) return '#54a7f8';
+  if (value >= 81) return '#ff5a47';
+  if (value >= 51) return '#54a7f8';
   return '#233a56';
 };
 

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -3,7 +3,6 @@ import { FaShieldAlt, FaStar, FaExclamationTriangle, FaBook, FaEye, FaChartLine 
 import FlowCurve from './FlowCurve';
 import ModelIconWithLabel from './ModelIconWithLabel';
 import RiskBadgeCard from './RiskBadgeCard';
-import DangerScoreCard from './DangerScoreCard';
 import RiskGauge from './RiskGauge';
 
 const models = [
@@ -78,7 +77,7 @@ const InferenceFlow = () => {
           <style>{`
             .flow-curve { animation: flowDash 1.2s linear infinite; filter: drop-shadow(0 0 10px #54e9f8cc); }
             @keyframes flowDash { to { stroke-dashoffset: -23; } }
-            .ring-pulse { transform-origin: center; animation: ringPulse 1.2s infinite; }
+            .ring-pulse { transform-box: fill-box; transform-origin: center; animation: ringPulse 1.2s infinite; }
             @keyframes ringPulse { 0%{transform:scale(1);opacity:0.6;}50%{transform:scale(1.25);opacity:0;}100%{transform:scale(1);opacity:0.6;} }
           `}</style>
         </defs>
@@ -125,7 +124,7 @@ const InferenceFlow = () => {
             <RiskBadgeCard
               score={scores[i]}
               state={getState(scores[i])}
-              x={736}
+              x={744}
               y={positions[i] - 16}
               highlight={i === maxIndex}
             />
@@ -133,8 +132,10 @@ const InferenceFlow = () => {
         ))}
         {/* Central network */}
         <g transform={`translate(400,${centerY})`}>
-          <circle r={29} stroke="#54e9f8" strokeWidth="2" fill="none" opacity="0.6" />
-          <circle r={29} stroke="#54e9f8" strokeWidth="2" fill="none" className="ring-pulse" />
+          <g className="ring-pulse">
+            <circle r={29} stroke="#54e9f8" strokeWidth="2" fill="none" opacity="0.6" />
+            <circle r={29} stroke="#54e9f8" strokeWidth="2" fill="none" />
+          </g>
           <circle cx="0" cy="0" r="3" fill="#54e9f8" />
           {Array.from({ length: 6 }).map((_, i) => {
             const angle = (i / 6) * 2 * Math.PI;
@@ -159,7 +160,6 @@ const InferenceFlow = () => {
             points={history.map((v, i) => `${i * 3},${40 - (v / 100) * 40}`).join(' ')}
           />
         </svg>
-        <DangerScoreCard score={scores[maxIndex]} state={getState(scores[maxIndex])} />
       </div>
     </div>
   );

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -135,7 +135,14 @@ const InferenceFlow = ({ onAlert }) => {
         {models.map((m, i) => {
           const y = positions[i];
           const inputPath = `M ${132 + shiftX} ${y} Q ${238 + shiftX} ${(y + centerY) / 2 - (2 - i) * 8}  ${326} ${centerY}`;
-          return <FlowCurve key={`in-${m.key}`} d={inputPath} />;
+          return (
+            <FlowCurve
+              key={`in-${m.key}`}
+              d={inputPath}
+              markerEnd="url(#arrow)"
+              dash="6 6"
+            />
+          );
         })}
         {/* Output lines */}
         {models.map((m, i) => {
@@ -147,7 +154,8 @@ const InferenceFlow = ({ onAlert }) => {
               d={outputPath}
               color={colorFor(scores[i])}
               width={scores[i] >= 80 ? 5 : 3}
-              marker="url(#arrow)"
+              markerEnd="url(#arrow)"
+              dash="6 6"
             />
           );
         })}
@@ -184,8 +192,8 @@ const InferenceFlow = ({ onAlert }) => {
         {/* Central network */}
         <g transform={`translate(${centerX},${centerY})`}>
           <g className="ring-pulse" style={{ transformOrigin: 'center' }}>
-            <circle r={33} stroke="#54e9f8" strokeWidth="2" fill="none" opacity="0.6" />
-            <circle r={33} stroke="#54e9f8" strokeWidth="2" fill="none" />
+            <circle r={36} stroke="#54a7f8" strokeWidth="2" fill="none" opacity="0.6" />
+            <circle r={36} stroke="#54a7f8" strokeWidth="2" fill="none" />
           </g>
           <circle cx="0" cy="0" r="3" fill="#54e9f8" />
           {Array.from({ length: 6 }).map((_, i) => {

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -171,7 +171,7 @@ const InferenceFlow = ({ onAlert }) => {
             <RiskBadgeCard
               score={scores[i]}
               state={getState(scores[i])}
-              x={745 + shiftX}
+              x={802 + shiftX}
               y={positions[i] - 16}
               highlight={i === maxIndex}
             />

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -139,7 +139,6 @@ const InferenceFlow = ({ onAlert }) => {
             <FlowCurve
               key={`in-${m.key}`}
               d={inputPath}
-              markerEnd="url(#arrow)"
               dash="6 6"
             />
           );

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -43,6 +43,8 @@ const InferenceFlow = () => {
   const iconStartY = 70;
   const iconSpacing = 40;
   const positions = models.map((_, i) => iconStartY + i * iconSpacing);
+  const shiftX = -30; // move entire flow 30px to the left
+  const centerX = 370 + shiftX; // central network position after shift
 
   return (
     <div className="flex items-center justify-center font-[Pretendard,sans-serif] text-xs">
@@ -81,13 +83,13 @@ const InferenceFlow = () => {
         {/* Input lines */}
         {models.map((m, i) => {
           const y = positions[i];
-          const inputPath = `M 132 ${y} Q 238 ${(y + centerY) / 2 - (2 - i) * 8} 366 ${centerY}`;
+          const inputPath = `M ${132 + shiftX} ${y} Q ${238 + shiftX} ${(y + centerY) / 2 - (2 - i) * 8}  ${326} ${centerY}`;
           return <FlowCurve key={`in-${m.key}`} d={inputPath} />;
         })}
         {/* Output lines */}
         {models.map((m, i) => {
           const y = positions[i];
-          const outputPath = `M 410 ${centerY} Q 538 ${(y + centerY) / 2 + (i - 2) * 8} 666 ${y}`;
+          const outputPath = `M ${380 + shiftX} ${centerY} Q ${508 + shiftX} ${(y + centerY) / 2 + (i - 2) * 8} ${636 + shiftX} ${y}`;
           return (
             <FlowCurve
               key={`out-${m.key}`}
@@ -103,7 +105,7 @@ const InferenceFlow = () => {
             key={`in-icon-${m.key}`}
             Icon={m.icon}
             label={m.label}
-            x={110}
+            x={110 + shiftX}
             y={positions[i]}
             align="left"
           />
@@ -114,21 +116,21 @@ const InferenceFlow = () => {
             <ModelIconWithLabel
               Icon={m.icon}
               label={m.label}
-              x={660}
+              x={660 + shiftX}
               y={positions[i]}
               align="right"
             />
             <RiskBadgeCard
               score={scores[i]}
               state={getState(scores[i])}
-              x={745}
+              x={745 + shiftX}
               y={positions[i] - 16}
               highlight={i === maxIndex}
             />
           </g>
         ))}
         {/* Central network */}
-        <g transform={`translate(370,${centerY})`}>
+        <g transform={`translate(${centerX},${centerY})`}>
           <g className="ring-pulse" style={{ transformOrigin: 'center' }}>
             <circle r={33} stroke="#54e9f8" strokeWidth="2" fill="none" opacity="0.6" />
             <circle r={33} stroke="#54e9f8" strokeWidth="2" fill="none" />
@@ -147,7 +149,7 @@ const InferenceFlow = () => {
           })}
         </g>
       </svg>
-      <div className="ml-[-30px] scale-[1.15] flex flex-col items-center">
+      <div className="ml-[-60px] scale-[1.15] flex flex-col items-center">
         <span className="text-[1.1rem] font-bold text-[#a2acc9] mb-1">Risk Score</span>
         <RiskGauge score={scores[maxIndex]} />
       </div>

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -6,13 +6,14 @@ import RiskBadgeCard from './RiskBadgeCard';
 import RiskGauge from './RiskGauge';
 import Toast from './Toast';
 
+// Model list with full descriptive names
 const models = [
-  { key: 'fraud', label: 'Fraud', icon: FiShield },
+  { key: 'fraud', label: 'Fraud Detector', icon: FiShield },
   { key: 'recommendation', label: 'Recommendation', icon: FiStar },
-  { key: 'anomaly', label: 'Anomaly', icon: FiAlertTriangle },
-  { key: 'language', label: 'Language', icon: FiBook },
-  { key: 'vision', label: 'Vision', icon: FiEye },
-  { key: 'forecast', label: 'Forecast', icon: FiBarChart2 },
+  { key: 'anomaly', label: 'Anomaly Watch', icon: FiAlertTriangle },
+  { key: 'language', label: 'Language Model', icon: FiBook },
+  { key: 'vision', label: 'Vision Classifier', icon: FiEye },
+  { key: 'forecast', label: 'Forecast Engine', icon: FiBarChart2 },
 ];
 
 const getState = (score) => {
@@ -84,7 +85,8 @@ const InferenceFlow = ({ onAlert }) => {
   const offsetY = -38;
   const centerY = 150 + offsetY;
   const iconStartY = 70 + offsetY;
-  const iconSpacing = 40;
+  // spacing between each model row to ensure labels fit
+  const iconSpacing = 46;
   const positions = models.map((_, i) => iconStartY + i * iconSpacing);
   const shiftX = -30; // move entire flow 30px to the left
   const centerX = 370 + shiftX; // central network position after shift

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -1,0 +1,168 @@
+import React, { useState, useEffect } from 'react';
+import { FaShieldAlt, FaStar, FaExclamationTriangle, FaBook, FaEye, FaChartLine } from 'react-icons/fa';
+import FlowCurve from './FlowCurve';
+import ModelIconWithLabel from './ModelIconWithLabel';
+import RiskBadgeCard from './RiskBadgeCard';
+import DangerScoreCard from './DangerScoreCard';
+import RiskGauge from './RiskGauge';
+
+const models = [
+  { key: 'fraud', label: 'Fraud', icon: FaShieldAlt },
+  { key: 'reco', label: 'Reco', icon: FaStar },
+  { key: 'anomaly', label: 'Anomaly', icon: FaExclamationTriangle },
+  { key: 'lang', label: 'Lang', icon: FaBook },
+  { key: 'vision', label: 'Vision', icon: FaEye },
+  { key: 'forecast', label: 'Forecast', icon: FaChartLine },
+];
+
+const getState = (score) => {
+  if (score >= 80) return 'DANGER';
+  if (score >= 50) return 'SUSPECT';
+  return 'NORMAL';
+};
+
+const colorFor = (score) => {
+  if (score >= 80) return 'url(#danger)';
+  if (score >= 50) return 'url(#warning)';
+  return 'url(#emerald)';
+};
+
+const InferenceFlow = () => {
+  const [scores, setScores] = useState(models.map(() => 50));
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const next = models.map(() => Math.floor(Math.random() * 101));
+      setScores(next);
+      const max = next.reduce((p, c, i) => (c > next[p] ? i : p), 0);
+      setHistory((h) => [...h.slice(-29), next[max]]);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const maxIndex = scores.reduce((p, c, i) => (c > scores[p] ? i : p), 0);
+
+  const centerY = 150;
+  const iconStartY = 70;
+  const iconSpacing = 40;
+  const positions = models.map((_, i) => iconStartY + i * iconSpacing);
+
+  return (
+    <div className="flex items-center justify-center font-[Pretendard,sans-serif] text-xs">
+      <svg viewBox="0 0 800 300" width="100%" height="300" className="block">
+        <defs>
+          <linearGradient id="emerald" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="#54e9f8" />
+            <stop offset="100%" stopColor="#34b4ff" />
+          </linearGradient>
+          <linearGradient id="warning" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="#ffb534" />
+            <stop offset="100%" stopColor="#ffde3e" />
+          </linearGradient>
+          <linearGradient id="danger" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stopColor="#ffb534" />
+            <stop offset="100%" stopColor="#ff5a47" />
+          </linearGradient>
+          <linearGradient id="iconGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#54e9f8" />
+            <stop offset="100%" stopColor="#395cd6" />
+          </linearGradient>
+          <filter id="iconGlow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="4" result="b" />
+            <feMerge>
+              <feMergeNode in="b" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+          <style>{`
+            .flow-curve { animation: flowDash 1.2s linear infinite; filter: drop-shadow(0 0 10px #54e9f8cc); }
+            @keyframes flowDash { to { stroke-dashoffset: -23; } }
+            .ring-pulse { transform-origin: center; animation: ringPulse 1.2s infinite; }
+            @keyframes ringPulse { 0%{transform:scale(1);opacity:0.6;}50%{transform:scale(1.25);opacity:0;}100%{transform:scale(1);opacity:0.6;} }
+          `}</style>
+        </defs>
+        {/* Input lines */}
+        {models.map((m, i) => {
+          const y = positions[i];
+          const inputPath = `M 132 ${y} Q 238 ${(y + centerY) / 2 - (2 - i) * 8} 366 ${centerY}`;
+          return <FlowCurve key={`in-${m.key}`} d={inputPath} />;
+        })}
+        {/* Output lines */}
+        {models.map((m, i) => {
+          const y = positions[i];
+          const outputPath = `M 434 ${centerY} Q 562 ${(y + centerY) / 2 + (i - 2) * 8} 690 ${y}`;
+          return (
+            <FlowCurve
+              key={`out-${m.key}`}
+              d={outputPath}
+              color={colorFor(scores[i])}
+              width={scores[i] >= 80 ? 5 : 3}
+            />
+          );
+        })}
+        {/* Input icons */}
+        {models.map((m, i) => (
+          <ModelIconWithLabel
+            key={`in-icon-${m.key}`}
+            Icon={m.icon}
+            label={m.label}
+            x={110}
+            y={positions[i]}
+            align="left"
+          />
+        ))}
+        {/* Output icons and badges */}
+        {models.map((m, i) => (
+          <g key={`out-icon-${m.key}`}>
+            <ModelIconWithLabel
+              Icon={m.icon}
+              label={m.label}
+              x={690}
+              y={positions[i]}
+              align="right"
+            />
+            <RiskBadgeCard
+              score={scores[i]}
+              state={getState(scores[i])}
+              x={736}
+              y={positions[i] - 16}
+              highlight={i === maxIndex}
+            />
+          </g>
+        ))}
+        {/* Central network */}
+        <g transform={`translate(400,${centerY})`}>
+          <circle r={29} stroke="#54e9f8" strokeWidth="2" fill="none" opacity="0.6" />
+          <circle r={29} stroke="#54e9f8" strokeWidth="2" fill="none" className="ring-pulse" />
+          <circle cx="0" cy="0" r="3" fill="#54e9f8" />
+          {Array.from({ length: 6 }).map((_, i) => {
+            const angle = (i / 6) * 2 * Math.PI;
+            const x = Math.cos(angle) * 24;
+            const y = Math.sin(angle) * 24;
+            return (
+              <g key={i}>
+                <line x1="0" y1="0" x2={x} y2={y} stroke="#54e9f8" strokeWidth="2" opacity="0.7" />
+                <circle cx={x} cy={y} r={4} fill="#54e9f8" />
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+      <div className="ml-4 flex items-center space-x-4">
+        <RiskGauge score={scores[maxIndex]} />
+        <svg width="100" height="40" className="text-[#4dd9ff]">
+          <polyline
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            points={history.map((v, i) => `${i * 3},${40 - (v / 100) * 40}`).join(' ')}
+          />
+        </svg>
+        <DangerScoreCard score={scores[maxIndex]} state={getState(scores[maxIndex])} />
+      </div>
+    </div>
+  );
+};
+
+export default InferenceFlow;

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -28,14 +28,11 @@ const colorFor = (score) => {
 
 const InferenceFlow = () => {
   const [scores, setScores] = useState(models.map(() => 50));
-  const [history, setHistory] = useState([]);
 
   useEffect(() => {
     const id = setInterval(() => {
       const next = models.map(() => Math.floor(Math.random() * 101));
       setScores(next);
-      const max = next.reduce((p, c, i) => (c > next[p] ? i : p), 0);
-      setHistory((h) => [...h.slice(-29), next[max]]);
     }, 1000);
     return () => clearInterval(id);
   }, []);
@@ -124,7 +121,7 @@ const InferenceFlow = () => {
             <RiskBadgeCard
               score={scores[i]}
               state={getState(scores[i])}
-              x={744}
+              x={740}
               y={positions[i] - 16}
               highlight={i === maxIndex}
             />
@@ -150,16 +147,8 @@ const InferenceFlow = () => {
           })}
         </g>
       </svg>
-      <div className="ml-4 flex items-center space-x-4">
+      <div className="ml-4">
         <RiskGauge score={scores[maxIndex]} />
-        <svg width="100" height="40" className="text-[#4dd9ff]">
-          <polyline
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            points={history.map((v, i) => `${i * 3},${40 - (v / 100) * 40}`).join(' ')}
-          />
-        </svg>
       </div>
     </div>
   );

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -80,15 +80,20 @@ const InferenceFlow = ({ onAlert }) => {
 
   const maxIndex = scores.reduce((p, c, i) => (c > scores[p] ? i : p), 0);
 
-  const centerY = 150;
-  const iconStartY = 70;
+  // Shift the entire flow upwards by roughly 1cm (~38px)
+  const offsetY = -38;
+  const centerY = 150 + offsetY;
+  const iconStartY = 70 + offsetY;
   const iconSpacing = 40;
   const positions = models.map((_, i) => iconStartY + i * iconSpacing);
   const shiftX = -30; // move entire flow 30px to the left
   const centerX = 370 + shiftX; // central network position after shift
 
   return (
-    <div className="flex items-center justify-center font-[Pretendard,sans-serif] text-xs">
+    <div
+      className="flex items-center justify-center font-[Pretendard,sans-serif] text-xs"
+      style={{ marginTop: `${offsetY}px` }}
+    >
       <svg viewBox="0 0 800 300" width="100%" height="300" className="block">
         <defs>
           <linearGradient id="emerald" x1="0" y1="0" x2="1" y2="0">

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -7,9 +7,9 @@ import RiskGauge from './RiskGauge';
 
 const models = [
   { key: 'fraud', label: 'Fraud', icon: FiShield },
-  { key: 'reco', label: 'Reco', icon: FiStar },
+  { key: 'recommendation', label: 'Recommendation', icon: FiStar },
   { key: 'anomaly', label: 'Anomaly', icon: FiAlertTriangle },
-  { key: 'lang', label: 'Lang', icon: FiBook },
+  { key: 'language', label: 'Language', icon: FiBook },
   { key: 'vision', label: 'Vision', icon: FiEye },
   { key: 'forecast', label: 'Forecast', icon: FiBarChart2 },
 ];
@@ -149,7 +149,7 @@ const InferenceFlow = () => {
           })}
         </g>
       </svg>
-      <div className="ml-[-60px] scale-[1.15] flex flex-col items-center">
+      <div className="ml-[-40px] scale-[1.15] flex flex-col items-center">
         <span className="text-[1.1rem] font-bold text-[#a2acc9] mb-1">Risk Score</span>
         <RiskGauge score={scores[maxIndex]} />
       </div>

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -1,17 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import { FaShieldAlt, FaStar, FaExclamationTriangle, FaBook, FaEye, FaChartLine } from 'react-icons/fa';
+import { FiShield, FiStar, FiAlertTriangle, FiBook, FiEye, FiBarChart2 } from 'react-icons/fi';
 import FlowCurve from './FlowCurve';
 import ModelIconWithLabel from './ModelIconWithLabel';
 import RiskBadgeCard from './RiskBadgeCard';
 import RiskGauge from './RiskGauge';
 
 const models = [
-  { key: 'fraud', label: 'Fraud', icon: FaShieldAlt },
-  { key: 'reco', label: 'Reco', icon: FaStar },
-  { key: 'anomaly', label: 'Anomaly', icon: FaExclamationTriangle },
-  { key: 'lang', label: 'Lang', icon: FaBook },
-  { key: 'vision', label: 'Vision', icon: FaEye },
-  { key: 'forecast', label: 'Forecast', icon: FaChartLine },
+  { key: 'fraud', label: 'Fraud', icon: FiShield },
+  { key: 'reco', label: 'Reco', icon: FiStar },
+  { key: 'anomaly', label: 'Anomaly', icon: FiAlertTriangle },
+  { key: 'lang', label: 'Lang', icon: FiBook },
+  { key: 'vision', label: 'Vision', icon: FiEye },
+  { key: 'forecast', label: 'Forecast', icon: FiBarChart2 },
 ];
 
 const getState = (score) => {
@@ -87,7 +87,7 @@ const InferenceFlow = () => {
         {/* Output lines */}
         {models.map((m, i) => {
           const y = positions[i];
-          const outputPath = `M 434 ${centerY} Q 562 ${(y + centerY) / 2 + (i - 2) * 8} 690 ${y}`;
+          const outputPath = `M 410 ${centerY} Q 538 ${(y + centerY) / 2 + (i - 2) * 8} 666 ${y}`;
           return (
             <FlowCurve
               key={`out-${m.key}`}
@@ -114,24 +114,24 @@ const InferenceFlow = () => {
             <ModelIconWithLabel
               Icon={m.icon}
               label={m.label}
-              x={690}
+              x={660}
               y={positions[i]}
               align="right"
             />
             <RiskBadgeCard
               score={scores[i]}
               state={getState(scores[i])}
-              x={740}
+              x={745}
               y={positions[i] - 16}
               highlight={i === maxIndex}
             />
           </g>
         ))}
         {/* Central network */}
-        <g transform={`translate(400,${centerY})`}>
-          <g className="ring-pulse">
-            <circle r={29} stroke="#54e9f8" strokeWidth="2" fill="none" opacity="0.6" />
-            <circle r={29} stroke="#54e9f8" strokeWidth="2" fill="none" />
+        <g transform={`translate(370,${centerY})`}>
+          <g className="ring-pulse" style={{ transformOrigin: 'center' }}>
+            <circle r={33} stroke="#54e9f8" strokeWidth="2" fill="none" opacity="0.6" />
+            <circle r={33} stroke="#54e9f8" strokeWidth="2" fill="none" />
           </g>
           <circle cx="0" cy="0" r="3" fill="#54e9f8" />
           {Array.from({ length: 6 }).map((_, i) => {
@@ -147,7 +147,8 @@ const InferenceFlow = () => {
           })}
         </g>
       </svg>
-      <div className="ml-4">
+      <div className="ml-[-30px] scale-[1.15] flex flex-col items-center">
+        <span className="text-[1.1rem] font-bold text-[#a2acc9] mb-1">Risk Score</span>
         <RiskGauge score={scores[maxIndex]} />
       </div>
     </div>

--- a/src/components/InferenceFlow.jsx
+++ b/src/components/InferenceFlow.jsx
@@ -114,6 +114,9 @@ const InferenceFlow = ({ onAlert }) => {
             <stop offset="0%" stopColor="#54e9f8" />
             <stop offset="100%" stopColor="#395cd6" />
           </linearGradient>
+          <marker id="arrow" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto" markerUnits="strokeWidth">
+            <path d="M0 0 L6 3 L0 6 Z" fill="#4dd9ff" />
+          </marker>
           <filter id="iconGlow" x="-50%" y="-50%" width="200%" height="200%">
             <feGaussianBlur stdDeviation="4" result="b" />
             <feMerge>
@@ -144,6 +147,7 @@ const InferenceFlow = ({ onAlert }) => {
               d={outputPath}
               color={colorFor(scores[i])}
               width={scores[i] >= 80 ? 5 : 3}
+              marker="url(#arrow)"
             />
           );
         })}

--- a/src/components/ModelIconWithLabel.jsx
+++ b/src/components/ModelIconWithLabel.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const ModelIconWithLabel = ({ Icon, label, x, y, align = 'center', pulse = 1 }) => (
+  <g transform={`translate(${x},${y})`} fontFamily="Pretendard,sans-serif">
+    <g
+      style={{
+        transform: `scale(${pulse})`,
+        filter: 'drop-shadow(0 0 8px #54e9f8cc)',
+        transition: 'transform 0.3s',
+      }}
+    >
+      <circle cx="0" cy="0" r="16" fill="url(#iconGrad)" filter="url(#iconGlow)" />
+      <Icon x="-8" y="-8" size={16} color="#131926" />
+    </g>
+    <text
+      x={align === 'left' ? -18 : align === 'right' ? 18 : 0}
+      y="26"
+      textAnchor={align === 'left' ? 'end' : align === 'right' ? 'start' : 'middle'}
+      fontSize="11"
+      fontWeight="bold"
+      fill="#a2acc9"
+      opacity="0.9"
+    >
+      {label}
+    </text>
+  </g>
+);
+
+export default ModelIconWithLabel;

--- a/src/components/ModelIconWithLabel.jsx
+++ b/src/components/ModelIconWithLabel.jsx
@@ -9,12 +9,12 @@ const ModelIconWithLabel = ({ Icon, label, x, y, align = 'center', pulse = 1 }) 
         transition: 'transform 0.3s',
       }}
     >
-      <circle cx="0" cy="0" r="16" fill="url(#iconGrad)" filter="url(#iconGlow)" />
-      <Icon x="-8" y="-8" size={16} color="#131926" />
+      <circle cx="0" cy="0" r="20" fill="url(#iconGrad)" filter="url(#iconGlow)" />
+      <Icon x="-10" y="-10" size={20} color="#131926" />
     </g>
     <text
       x={align === 'left' ? -18 : align === 'right' ? 18 : 0}
-      y="26"
+      y="34"
       textAnchor={align === 'left' ? 'end' : align === 'right' ? 'start' : 'middle'}
       fontSize="11"
       fontWeight="bold"

--- a/src/components/ModelIconWithLabel.jsx
+++ b/src/components/ModelIconWithLabel.jsx
@@ -13,7 +13,7 @@ const ModelIconWithLabel = ({ Icon, label, x, y, align = 'center', pulse = 1 }) 
       <Icon x="-10" y="-10" size={20} color="#131926" />
     </g>
     <text
-      x={align === 'left' ? -18 : align === 'right' ? 18 : 0}
+      x={align === 'left' ? -24 : align === 'right' ? 24 : 0}
       y="34"
       textAnchor={align === 'left' ? 'end' : align === 'right' ? 'start' : 'middle'}
       fontSize="11"

--- a/src/components/ModelIconWithLabel.jsx
+++ b/src/components/ModelIconWithLabel.jsx
@@ -16,10 +16,11 @@ const ModelIconWithLabel = ({ Icon, label, x, y, align = 'center', pulse = 1 }) 
       x={align === 'left' ? -24 : align === 'right' ? 24 : 0}
       y="34"
       textAnchor={align === 'left' ? 'end' : align === 'right' ? 'start' : 'middle'}
-      fontSize="11"
+      fontSize="13"
       fontWeight="bold"
       fill="#a2acc9"
       opacity="0.9"
+      style={{ whiteSpace: 'nowrap' }}
     >
       {label}
     </text>

--- a/src/components/ModelStatus.jsx
+++ b/src/components/ModelStatus.jsx
@@ -25,7 +25,7 @@ const statusColor = (status) => {
   }
 };
 
-const ModelStatus = () => {
+const ModelStatus = ({ filter = '' }) => {
   const [models, setModels] = useState(initialModels);
 
   useEffect(() => {
@@ -40,9 +40,13 @@ const ModelStatus = () => {
     return () => clearInterval(interval);
   }, []);
 
+  const filtered = models.filter((m) =>
+    m.name.toLowerCase().includes(filter.toLowerCase())
+  );
+
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-      {models.map((model, i) => (
+      {filtered.map((model, i) => (
         <div key={i} className="bg-[#192232] rounded-xl p-4 shadow">
           <div className="text-sm text-gray-400">{model.name}</div>
           <div className="text-2xl font-bold" style={{ color: statusColor(model.status) }}>

--- a/src/components/ModelStatus.jsx
+++ b/src/components/ModelStatus.jsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+
+const initialModels = [
+  { name: 'Fraud Detector', percent: 92.1, status: 'Active' },
+  { name: 'Recommendation', percent: 76.4, status: 'Drift' },
+  { name: 'Anomaly Watch', percent: 61.3, status: 'Audit' },
+  { name: 'Language Model', percent: 84.7, status: 'AI Risk' },
+  { name: 'Vision Classifier', percent: 49.5, status: 'Active' },
+  { name: 'Forecast Engine', percent: 73.2, status: 'High' },
+];
+
+const statusColor = (status) => {
+  switch (status) {
+    case 'Active':
+      return '#34b4ff';
+    case 'Drift':
+      return '#ffb534';
+    case 'AI Risk':
+    case 'High':
+      return '#ff5a47';
+    case 'Audit':
+      return '#54a7f8';
+    default:
+      return '#54a7f8';
+  }
+};
+
+const ModelStatus = () => {
+  const [models, setModels] = useState(initialModels);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setModels((prev) =>
+        prev.map((m) => ({
+          ...m,
+          percent: Math.min(100, Math.max(0, m.percent + (Math.random() * 4 - 2))),
+        }))
+      );
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+      {models.map((model, i) => (
+        <div key={i} className="bg-[#192232] rounded-xl p-4 shadow">
+          <div className="text-sm text-gray-400">{model.name}</div>
+          <div className="text-2xl font-bold" style={{ color: statusColor(model.status) }}>
+            {model.percent.toFixed(1)}%
+          </div>
+          <span
+            className="inline-block text-xs font-bold mt-1 rounded"
+            style={{ backgroundColor: statusColor(model.status), color: '#fff', padding: '2px 8px' }}
+          >
+            {model.status}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ModelStatus;

--- a/src/components/PromptGuard.jsx
+++ b/src/components/PromptGuard.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function PromptGuard() {
+  const [logs, setLogs] = useState([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setLogs((l) => [
+        ...l.slice(-4),
+        { text: 'Potential injection detected', time: new Date().toLocaleTimeString() },
+      ]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="bg-[#171f2e] p-4 rounded-lg">
+      <div className="font-semibold mb-2">Prompt Guard</div>
+      <ul className="text-sm space-y-1">
+        {logs.map((log, i) => (
+          <li key={i}>[{log.time}] {log.text}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/RateLimitConfigPanel.jsx
+++ b/src/components/RateLimitConfigPanel.jsx
@@ -1,0 +1,8 @@
+export default function RateLimitConfigPanel() {
+  return (
+    <div className="bg-[#171f2e] p-4 rounded-lg">
+      <div className="font-semibold mb-2">Rate Limit Config</div>
+      <div className="text-sm text-gray-400">(configuration UI here)</div>
+    </div>
+  );
+}

--- a/src/components/RateLimitTable.jsx
+++ b/src/components/RateLimitTable.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function RateLimitTable() {
+  const [rows, setRows] = useState([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRows([
+        { client: 'token1', count: Math.floor(Math.random()*50) },
+        { client: 'token2', count: Math.floor(Math.random()*50) },
+      ]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <table className="w-full bg-[#171f2e] rounded-lg p-4">
+      <thead><tr><th>Client</th><th>Req/min</th></tr></thead>
+      <tbody>
+        {rows.map(r=>(
+          <tr key={r.client} className="text-center"><td>{r.client}</td><td>{r.count}</td></tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/ReportsPage.jsx
+++ b/src/components/ReportsPage.jsx
@@ -1,9 +1,22 @@
 import React from 'react';
 
+const reports = [
+  { name: 'Weekly Risk Summary', date: '2025-06-18' },
+  { name: 'Monthly Performance', date: '2025-06-01' },
+  { name: 'Anomaly Log', date: '2025-05-28' },
+];
+
 const ReportsPage = () => (
   <div className="p-6 space-y-4">
     <h2 className="text-xl font-semibold mb-4">Reports</h2>
-    <p>Report generation coming soon.</p>
+    <ul className="space-y-2">
+      {reports.map((r) => (
+        <li key={r.name} className="flex justify-between items-center bg-[#171f2e] p-3 rounded">
+          <span>{r.name} ({r.date})</span>
+          <button className="text-sm px-3 py-1 rounded bg-[#34b4ff] text-white">Download</button>
+        </li>
+      ))}
+    </ul>
   </div>
 );
 

--- a/src/components/ReportsPage.jsx
+++ b/src/components/ReportsPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const ReportsPage = () => (
+  <div className="p-6 space-y-4">
+    <h2 className="text-xl font-semibold mb-4">Reports</h2>
+    <p>Report generation coming soon.</p>
+  </div>
+);
+
+export default ReportsPage;

--- a/src/components/RiskBadgeCard.jsx
+++ b/src/components/RiskBadgeCard.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const RiskBadgeCard = ({ score, state, x, y, highlight }) => (
+  <g transform={`translate(${x},${y})`} fontFamily="Pretendard,sans-serif" textAnchor="middle">
+    <rect
+      x="0"
+      y="0"
+      width="46"
+      height="32"
+      rx="7"
+      fill="#232b3b"
+      stroke={highlight ? '#ff5a47' : 'none'}
+      style={highlight ? { filter: 'drop-shadow(0 0 8px #ff5a47aa)' } : undefined}
+    />
+    <text x="23" y="14" fontSize="1.1rem" fontWeight="bold" fill={highlight ? '#ff5a47' : '#54e9f8'} dy="0.35em">
+      {score}
+    </text>
+    <text x="23" y="24" fontSize="10" fill="#a2acc9">
+      {state}
+    </text>
+  </g>
+);
+
+export default RiskBadgeCard;

--- a/src/components/RiskBadgeCard.jsx
+++ b/src/components/RiskBadgeCard.jsx
@@ -5,17 +5,17 @@ const RiskBadgeCard = ({ score, state, x, y, highlight }) => (
     <rect
       x="0"
       y="0"
-      width="56"
-      height="32"
+      width="60"
+      height="34"
       rx="7"
       fill="#232b3b"
       stroke={highlight ? '#ff5a47' : 'none'}
       style={highlight ? { filter: 'drop-shadow(0 0 8px #ff5a47aa)' } : undefined}
     />
-    <text x="28" y="14" fontSize="1.1rem" fontWeight="bold" fill={highlight ? '#ff5a47' : '#54e9f8'} dy="0.35em">
+    <text x="30" y="16" fontSize="1.1rem" fontWeight="bold" fill={highlight ? '#ff5a47' : '#54e9f8'} dy="0.35em">
       {score}
     </text>
-    <text x="28" y="24" fontSize="10" fill="#a2acc9">
+    <text x="30" y="28" fontSize="10" fill="#a2acc9">
       {state}
     </text>
   </g>

--- a/src/components/RiskBadgeCard.jsx
+++ b/src/components/RiskBadgeCard.jsx
@@ -1,21 +1,32 @@
 import React from 'react';
 
 const RiskBadgeCard = ({ score, state, x, y, highlight }) => (
-  <g transform={`translate(${x},${y})`} fontFamily="Pretendard,sans-serif" textAnchor="middle">
+  <g
+    transform={`translate(${x},${y})`}
+    fontFamily="Pretendard,sans-serif"
+    textAnchor="middle"
+  >
     <rect
       x="0"
       y="0"
-      width="60"
-      height="34"
+      width="54"
+      height="38"
       rx="7"
       fill="#232b3b"
       stroke={highlight ? '#ff5a47' : 'none'}
       style={highlight ? { filter: 'drop-shadow(0 0 8px #ff5a47aa)' } : undefined}
     />
-    <text x="30" y="16" fontSize="1.1rem" fontWeight="bold" fill={highlight ? '#ff5a47' : '#54e9f8'} dy="0.35em">
+    <text
+      x="27"
+      y="17"
+      className="risk-card-number"
+      fontSize="1.35rem"
+      fontWeight="bold"
+      fill={highlight ? '#ff5a47' : '#54e9f8'}
+    >
       {score}
     </text>
-    <text x="30" y="28" fontSize="10" fill="#a2acc9">
+    <text x="27" y="31" className="risk-card-label" fontSize="10" fill="#a2acc9">
       {state}
     </text>
   </g>

--- a/src/components/RiskBadgeCard.jsx
+++ b/src/components/RiskBadgeCard.jsx
@@ -5,17 +5,17 @@ const RiskBadgeCard = ({ score, state, x, y, highlight }) => (
     <rect
       x="0"
       y="0"
-      width="46"
+      width="56"
       height="32"
       rx="7"
       fill="#232b3b"
       stroke={highlight ? '#ff5a47' : 'none'}
       style={highlight ? { filter: 'drop-shadow(0 0 8px #ff5a47aa)' } : undefined}
     />
-    <text x="23" y="14" fontSize="1.1rem" fontWeight="bold" fill={highlight ? '#ff5a47' : '#54e9f8'} dy="0.35em">
+    <text x="28" y="14" fontSize="1.1rem" fontWeight="bold" fill={highlight ? '#ff5a47' : '#54e9f8'} dy="0.35em">
       {score}
     </text>
-    <text x="23" y="24" fontSize="10" fill="#a2acc9">
+    <text x="28" y="24" fontSize="10" fill="#a2acc9">
       {state}
     </text>
   </g>

--- a/src/components/RiskGauge.jsx
+++ b/src/components/RiskGauge.jsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect } from 'react';
+
+const colorHex = (score) => {
+  if (score > 80) return '#ff5a47';
+  if (score > 50) return '#ffb534';
+  return '#54a7f8';
+};
+
+const RiskGauge = ({ score: external }) => {
+  const [score, setScore] = useState(external ?? 0);
+
+  useEffect(() => {
+    if (external === undefined) {
+      const interval = setInterval(() => {
+        setScore(Math.floor(Math.random() * 101));
+      }, 1000);
+      return () => clearInterval(interval);
+    }
+  }, [external]);
+
+  useEffect(() => {
+    if (external !== undefined) setScore(external);
+  }, [external]);
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative w-24 h-24">
+        <svg viewBox="0 0 36 36" className="w-full h-full rotate-[-90deg]" style={{ color: colorHex(score) }}>
+          <defs>
+            <linearGradient id="riskGrad" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stopColor="#ffb534" />
+              <stop offset="100%" stopColor="#ff5a47" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M18 2.0845
+              a 15.9155 15.9155 0 0 1 0 31.831
+              a 15.9155 15.9155 0 0 1 0 -31.831"
+            fill="none"
+            stroke="#2d3748"
+            strokeWidth="2"
+          />
+          <path
+            d="M18 2.0845
+              a 15.9155 15.9155 0 0 1 0 31.831"
+            fill="none"
+            stroke={score > 80 ? 'url(#riskGrad)' : 'currentColor'}
+            strokeWidth="2"
+            strokeDasharray={`${score}, 100`}
+          />
+        </svg>
+        <div
+          className="absolute inset-0 flex items-center justify-center text-xl font-bold"
+          style={{ color: colorHex(score) }}
+        >
+          {score}%
+        </div>
+      </div>
+      <span className="mt-2 font-medium" style={{ color: colorHex(score) }}>
+        Risk Score
+      </span>
+    </div>
+  );
+};
+
+export default RiskGauge;

--- a/src/components/RiskGauge.jsx
+++ b/src/components/RiskGauge.jsx
@@ -28,7 +28,8 @@ const RiskGauge = ({ score: external }) => {
         <svg viewBox="0 0 36 36" className="w-full h-full rotate-[-90deg]" style={{ color: colorHex(score) }}>
           <defs>
             <linearGradient id="riskGrad" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stopColor="#ffb534" />
+              <stop offset="0%" stopColor="#54a7f8" />
+              <stop offset="50%" stopColor="#ffb534" />
               <stop offset="100%" stopColor="#ff5a47" />
             </linearGradient>
           </defs>
@@ -44,7 +45,7 @@ const RiskGauge = ({ score: external }) => {
             d="M18 2.0845
               a 15.9155 15.9155 0 0 1 0 31.831"
             fill="none"
-            stroke={score > 80 ? 'url(#riskGrad)' : 'currentColor'}
+            stroke="url(#riskGrad)"
             strokeWidth="2"
             strokeDasharray={`${score}, 100`}
           />

--- a/src/components/RiskInsights.jsx
+++ b/src/components/RiskInsights.jsx
@@ -1,11 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Heatmap from './Heatmap';
 
-const RiskInsights = () => (
-  <div className="p-6 space-y-4">
-    <h2 className="text-xl font-semibold mb-4">Risk Insights</h2>
-    <Heatmap />
-  </div>
-);
+const generateData = () =>
+  Array.from({ length: 20 }, () => 50 + Math.random() * 50);
+
+const RiskInsights = () => {
+  const [data, setData] = useState(generateData());
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setData((d) => [...d.slice(1), 50 + Math.random() * 50]);
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const points = data.map((v, i) => `${i * 10},${100 - v}`).join(' ');
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-semibold mb-4">Risk Insights</h2>
+      <svg viewBox="0 0 200 100" className="w-full h-24" fill="none">
+        <polyline
+          points={points}
+          stroke="#54a7f8"
+          strokeWidth="2"
+          fill="none"
+        />
+      </svg>
+      <Heatmap />
+    </div>
+  );
+};
 
 export default RiskInsights;

--- a/src/components/RiskInsights.jsx
+++ b/src/components/RiskInsights.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Heatmap from './Heatmap';
+
+const RiskInsights = () => (
+  <div className="p-6 space-y-4">
+    <h2 className="text-xl font-semibold mb-4">Risk Insights</h2>
+    <Heatmap />
+  </div>
+);
+
+export default RiskInsights;

--- a/src/components/SecurityLogPanel.jsx
+++ b/src/components/SecurityLogPanel.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function SecurityLogPanel() {
+  const [logs, setLogs] = useState([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setLogs((l) => [
+        ...l.slice(-4),
+        { text: 'Failed auth', time: new Date().toLocaleTimeString() },
+      ]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="bg-[#171f2e] p-4 rounded-lg">
+      <div className="font-semibold mb-2">Security Log</div>
+      <ul className="text-sm space-y-1">
+        {logs.map((log, i) => (
+          <li key={i}>[{log.time}] {log.text}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/SettingsPage.jsx
+++ b/src/components/SettingsPage.jsx
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-const SettingsPage = () => (
-  <div className="p-6 space-y-4">
-    <h2 className="text-xl font-semibold mb-4">Settings</h2>
-    <p>Configuration options will appear here.</p>
-  </div>
-);
+const SettingsPage = () => {
+  const [dark, setDark] = useState(true);
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-semibold mb-4">Settings</h2>
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={dark}
+          onChange={() => setDark(!dark)}
+        />
+        Dark Theme
+      </label>
+      <p className="text-sm text-gray-400">Theme toggle demo only.</p>
+    </div>
+  );
+};
 
 export default SettingsPage;

--- a/src/components/SettingsPage.jsx
+++ b/src/components/SettingsPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const SettingsPage = () => (
+  <div className="p-6 space-y-4">
+    <h2 className="text-xl font-semibold mb-4">Settings</h2>
+    <p>Configuration options will appear here.</p>
+  </div>
+);
+
+export default SettingsPage;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -22,7 +22,18 @@ const items = [
   { icon: <FaCog />, label: 'Settings' },
 ];
 
+import { useState } from 'react';
+
 const Sidebar = ({ activeItem, onSelect }) => {
+  const [open, setOpen] = useState({});
+
+  const toggle = (label) => {
+    setOpen((o) => ({ ...o, [label]: !o[label] }));
+  };
+
+  const isChildActive = (item) =>
+    item.children && item.children.some((c) => c.key === activeItem);
+
   return (
     <aside className="w-[240px] bg-[#1a2235] p-6 space-y-4">
       <div className="flex items-center text-2xl font-bold mb-8">
@@ -69,10 +80,12 @@ const Sidebar = ({ activeItem, onSelect }) => {
             <SidebarItem
               icon={item.icon}
               label={item.label}
-              active={activeItem === item.label}
-              onClick={() => onSelect(item.label)}
+              active={activeItem === item.label || isChildActive(item)}
+              onClick={() =>
+                item.children ? toggle(item.label) : onSelect(item.label)
+              }
             />
-            {item.children && (
+            {item.children && open[item.label] && (
               <div className="ml-6 flex flex-col space-y-2">
                 {item.children.map((child) => (
                   <SidebarItem

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -12,8 +12,45 @@ const items = [
 
 const Sidebar = ({ activeItem, onSelect }) => {
   return (
-    <aside className="w-64 bg-[#1a1f29] p-6 space-y-4">
-      <div className="text-2xl font-bold mb-8">AuditMind</div>
+    <aside className="w-[240px] bg-[#1a2235] p-6 space-y-4">
+      <div className="flex items-center text-2xl font-bold mb-8">
+        <svg
+          className="w-10 h-10 drop-shadow-lg"
+          viewBox="0 0 56 56"
+          fill="url(#auditBlue)"
+          style={{ animation: 'blueGlow 2s infinite' }}
+        >
+          <defs>
+            <linearGradient id="auditBlue" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#b8e2ff" />
+              <stop offset="50%" stopColor="#34b4ff" />
+              <stop offset="100%" stopColor="#395cd6" />
+            </linearGradient>
+            <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+              <feGaussianBlur stdDeviation="6" result="coloredBlur" />
+              <feMerge>
+                <feMergeNode in="coloredBlur" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+          </defs>
+          <style>{`
+            @keyframes blueGlow {
+              0% { filter: drop-shadow(0 0 8px #54a7f8aa); }
+              50% { filter: drop-shadow(0 0 26px #54a7f8ff) brightness(1.18) saturate(1.2); transform: scale(1.04); }
+              100% { filter: drop-shadow(0 0 8px #54a7f8aa); }
+            }
+          `}</style>
+          <path
+            d="M13 46 L28 10 L43 46 Q38 41 18 41 Z"
+            stroke="#ffffff"
+            strokeOpacity="0.2"
+            strokeWidth="2.5"
+            filter="url(#glow)"
+          />
+        </svg>
+        <span className="ml-2">AuditMind</span>
+      </div>
       <nav className="flex flex-col space-y-4">
         {items.map((item) => (
           <SidebarItem

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { FaChartBar, FaRobot, FaBell, FaFileAlt, FaCog } from 'react-icons/fa';
+import { FaChartBar, FaRobot, FaBell, FaFileAlt, FaCog, FaShieldAlt } from 'react-icons/fa';
 
 const items = [
   { icon: <FaChartBar />, label: 'Dashboard' },
   { icon: <FaRobot />, label: 'AI Models' },
   { icon: <FaChartBar />, label: 'Risk Insights' },
+  { icon: <FaShieldAlt />, label: 'ARM (AI Risk Manager)' },
   { icon: <FaBell />, label: 'Alerts' },
   { icon: <FaFileAlt />, label: 'Reports' },
   { icon: <FaCog />, label: 'Settings' },

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,7 +5,18 @@ const items = [
   { icon: <FaChartBar />, label: 'Dashboard' },
   { icon: <FaRobot />, label: 'AI Models' },
   { icon: <FaChartBar />, label: 'Risk Insights' },
-  { icon: <FaShieldAlt />, label: 'ARM (AI Risk Manager)' },
+  {
+    icon: <FaShieldAlt />,
+    label: 'API Manager',
+    children: [
+      { label: 'Dashboard', key: 'API Manager Dashboard' },
+      { label: 'API Risk', key: 'API Manager API Risk' },
+      { label: 'Traffic Guard', key: 'API Manager Traffic Guard' },
+      { label: 'Token Watch', key: 'API Manager Token Watch' },
+      { label: 'Prompt Filter', key: 'API Manager Prompt Filter' },
+      { label: 'Security Log', key: 'API Manager Security Log' },
+    ],
+  },
   { icon: <FaBell />, label: 'Alerts' },
   { icon: <FaFileAlt />, label: 'Reports' },
   { icon: <FaCog />, label: 'Settings' },
@@ -54,27 +65,41 @@ const Sidebar = ({ activeItem, onSelect }) => {
       </div>
       <nav className="flex flex-col space-y-4">
         {items.map((item) => (
-          <SidebarItem
-            key={item.label}
-            icon={item.icon}
-            label={item.label}
-            active={activeItem === item.label}
-            onClick={() => onSelect(item.label)}
-          />
+          <React.Fragment key={item.label}>
+            <SidebarItem
+              icon={item.icon}
+              label={item.label}
+              active={activeItem === item.label}
+              onClick={() => onSelect(item.label)}
+            />
+            {item.children && (
+              <div className="ml-6 flex flex-col space-y-2">
+                {item.children.map((child) => (
+                  <SidebarItem
+                    key={child.key}
+                    label={child.label}
+                    active={activeItem === child.key}
+                    onClick={() => onSelect(child.key)}
+                    small
+                  />
+                ))}
+              </div>
+            )}
+          </React.Fragment>
         ))}
       </nav>
     </aside>
   );
 };
 
-const SidebarItem = ({ icon, label, active, onClick }) => (
+const SidebarItem = ({ icon, label, active, onClick, small }) => (
   <div
     onClick={onClick}
     className={`flex items-center space-x-3 px-3 py-2 rounded-lg cursor-pointer hover:bg-[#2a2f3a] ${
       active ? 'bg-[#2a2f3a] font-semibold' : ''
-    }`}
+    } ${small ? 'text-sm ml-4' : ''}`}
   >
-    {icon}
+    {icon && icon}
     <span>{label}</span>
   </div>
 );

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const colors = {
+  info: '#54a7f8',
+  success: '#34b4ff',
+  error: '#ff5a47',
+};
+
+const Toast = ({ message, type }) => (
+  <div
+    className="fixed top-4 right-4 px-4 py-2 rounded text-sm font-medium text-white z-50"
+    style={{ backgroundColor: colors[type] || '#54a7f8', boxShadow: '0 2px 12px rgba(0,0,0,0.5)' }}
+  >
+    {message}
+  </div>
+);
+
+export default Toast;

--- a/src/components/TokenAbuseTable.jsx
+++ b/src/components/TokenAbuseTable.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export default function TokenAbuseTable() {
+  const [rows, setRows] = useState([]);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRows([
+        { token: 'abc123', count: Math.floor(Math.random()*100) },
+        { token: 'def456', count: Math.floor(Math.random()*100) },
+      ]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <table className="w-full bg-[#171f2e] rounded-lg p-4">
+      <thead><tr><th>Token</th><th>Calls</th></tr></thead>
+      <tbody>
+        {rows.map(r=>(
+          <tr key={r.token} className="text-center"><td>{r.token}</td><td>{r.count}</td></tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -17,7 +17,10 @@ const Topbar = ({ lastUpdate }) => {
       <h1 className="text-2xl font-semibold">AI Risk Management Dashboard</h1>
       <div className="flex items-center gap-4">
         <span className="text-sm text-gray-400">Updated {elapsed}s ago</span>
-        <button className="bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-2 rounded-lg font-medium">
+        <button
+          className="text-white text-sm px-4 py-2 rounded-lg font-medium"
+          style={{ background: 'linear-gradient(90deg,#34b4ff,#54a7f8)' }}
+        >
           Download Report
         </button>
       </div>

--- a/src/components/TrafficGuard.jsx
+++ b/src/components/TrafficGuard.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+export default function TrafficGuard() {
+  const [status, setStatus] = useState({ limit: 1000, current: 0 });
+  useEffect(() => {
+    const id = setInterval(() => {
+      setStatus({ limit: 1000, current: Math.floor(Math.random() * 1000) });
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div className="bg-[#171f2e] p-4 rounded-lg">
+      <div className="font-semibold mb-2">Traffic Guard</div>
+      <div>Limit: {status.limit} req/min</div>
+      <div>Current: {status.current} req/min</div>
+    </div>
+  );
+}

--- a/src/pages/api-manager/index.jsx
+++ b/src/pages/api-manager/index.jsx
@@ -1,0 +1,14 @@
+import APICallStatsCard from '../../components/APICallStatsCard';
+import AlertHub from '../../components/AlertHub';
+import TrafficGuard from '../../components/TrafficGuard';
+
+export default function APIMDashboard() {
+  return (
+    <div className="p-6 space-y-6 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-3xl font-bold">🛡️ API Manager Dashboard</h1>
+      <APICallStatsCard />
+      <AlertHub />
+      <TrafficGuard />
+    </div>
+  );
+}

--- a/src/pages/api-manager/index.tsx
+++ b/src/pages/api-manager/index.tsx
@@ -1,0 +1,14 @@
+import APICallStatsCard from "@/components/APICallStatsCard";
+import AlertHub from "@/components/AlertHub";
+import TrafficGuard from "@/components/TrafficGuard";
+
+export default function APIDashboard() {
+  return (
+    <div className="p-6 space-y-6 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-3xl font-bold">🛡️ API Manager Dashboard</h1>
+      <APICallStatsCard />
+      <AlertHub />
+      <TrafficGuard />
+    </div>
+  );
+}

--- a/src/pages/api-manager/prompt.jsx
+++ b/src/pages/api-manager/prompt.jsx
@@ -1,0 +1,10 @@
+import PromptGuard from '../../components/PromptGuard';
+
+export default function PromptPage() {
+  return (
+    <div className="p-6 space-y-6 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-3xl font-bold">Prompt Filter</h1>
+      <PromptGuard />
+    </div>
+  );
+}

--- a/src/pages/api-manager/risk.jsx
+++ b/src/pages/api-manager/risk.jsx
@@ -1,0 +1,10 @@
+import APIErrorTable from '../../components/APIErrorTable';
+
+export default function APIRiskPage() {
+  return (
+    <div className="p-6 space-y-6 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-3xl font-bold">API Risk</h1>
+      <APIErrorTable />
+    </div>
+  );
+}

--- a/src/pages/api-manager/security.jsx
+++ b/src/pages/api-manager/security.jsx
@@ -1,0 +1,10 @@
+import SecurityLogPanel from '../../components/SecurityLogPanel';
+
+export default function SecurityPage() {
+  return (
+    <div className="p-6 space-y-6 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-3xl font-bold">Security Log</h1>
+      <SecurityLogPanel />
+    </div>
+  );
+}

--- a/src/pages/api-manager/token.jsx
+++ b/src/pages/api-manager/token.jsx
@@ -1,0 +1,10 @@
+import TokenAbuseTable from '../../components/TokenAbuseTable';
+
+export default function TokenPage() {
+  return (
+    <div className="p-6 space-y-6 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-3xl font-bold">Token Watch</h1>
+      <TokenAbuseTable />
+    </div>
+  );
+}

--- a/src/pages/api-manager/traffic.jsx
+++ b/src/pages/api-manager/traffic.jsx
@@ -1,0 +1,16 @@
+import TrafficGuard from '../../components/TrafficGuard';
+import RateLimitConfigPanel from '../../components/RateLimitConfigPanel';
+import RateLimitTable from '../../components/RateLimitTable';
+import BlockedClientsList from '../../components/BlockedClientsList';
+
+export default function TrafficPage() {
+  return (
+    <div className="p-6 space-y-6 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-3xl font-bold">Traffic Guard</h1>
+      <TrafficGuard />
+      <RateLimitConfigPanel />
+      <RateLimitTable />
+      <BlockedClientsList />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- colorize flow lines by risk level
- pulse network nodes for livelier animation
- tweak KPI card sizes and heatmap placement
- refine inference flow visuals and adjust danger score layout

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573c2a7da48327b70326581f16ecc7