### PR TITLE
Add APIWatcher component

### DIFF
--- a/src/components/APIWatcher.jsx
+++ b/src/components/APIWatcher.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Card, CardHeader, CardContent } from './ui/card';
+
+const mockApiStats = {
+  totalCalls: 5481,
+  errorRate: 2.4,
+  avgLatencyMs: 245,
+  highRiskEndpoints: [
+    { endpoint: '/v1/completions', errorRate: 7.8, avgLatency: 623 },
+    { endpoint: '/v1/search', errorRate: 5.1, avgLatency: 440 },
+  ],
+};
+
+const APIWatcher = () => {
+  return (
+    <Card className="w-full bg-slate-900 text-white p-6 rounded-2xl shadow-xl">
+      <CardHeader className="text-2xl font-semibold pb-4">API Risk Overview</CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-3 gap-4 mb-6">
+          <div className="text-lg">✅ Total Calls: {mockApiStats.totalCalls}</div>
+          <div className="text-lg">⚠️ Error Rate: {mockApiStats.errorRate}%</div>
+          <div className="text-lg">📉 Avg Latency: {mockApiStats.avgLatencyMs}ms</div>
+        </div>
+        <div className="pt-2">
+          <h3 className="text-xl font-semibold mb-2">🔍 High Risk Endpoints</h3>
+          <table className="w-full text-left border-t border-slate-700">
+            <thead>
+              <tr className="text-slate-300">
+                <th className="py-2">Endpoint</th>
+                <th>Error Rate (%)</th>
+                <th>Avg Latency (ms)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mockApiStats.highRiskEndpoints.map((api) => (
+                <tr key={api.endpoint} className="border-t border-slate-700 hover:bg-slate-800">
+                  <td className="py-2">{api.endpoint}</td>
+                  <td>{api.errorRate}</td>
+                  <td>{api.avgLatency}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default APIWatcher;

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import RiskGauge from './RiskGauge';
 import ModelStatus from './ModelStatus';
 import Heatmap from './Heatmap';
+import APIWatcher from './APIWatcher';
 
 const initialStats = [
   { label: 'AI Models', value: 52 },
@@ -122,6 +123,8 @@ const Dashboard = ({ onUpdate }) => {
           </tbody>
         </table>
       </div>
+
+      <APIWatcher />
     </div>
   );
 };

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export const Card = ({ className = '', children }) => (
+  <div className={`bg-[#1a1f29] rounded-xl shadow-lg ${className}`}>{children}</div>
+);
+
+export const CardHeader = ({ className = '', children }) => (
+  <div className={`mb-4 ${className}`}>{children}</div>
+);
+
+export const CardContent = ({ className = '', children }) => (
+  <div className={className}>{children}</div>
+);


### PR DESCRIPTION
## Summary
- implement `APIWatcher` component
- add simple `Card` UI helpers
- render APIWatcher on the dashboard

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0df97ac88327a0369acff4c83b16