### PR TITLE
Integrate ARM dashboard page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Sidebar from './components/Sidebar';
 import Topbar from './components/Topbar';
 import Dashboard from './components/Dashboard';
+import ARMDashboard from './components/ARMDashboard';
 
 const App = () => {
+  const [active, setActive] = useState('Dashboard');
+  const [lastUpdate, setLastUpdate] = useState(Date.now());
+
+  const renderContent = () => {
+    if (active === 'Dashboard') {
+      return <Dashboard onUpdate={() => setLastUpdate(Date.now())} />;
+    }
+    if (active === 'ARM (AI Risk Manager)') {
+      return <ARMDashboard />;
+    }
+    return <div className="p-6 text-gray-400">{active} page coming soon...</div>;
+  };
+
   return (
     <div className="flex h-screen bg-[#0e1116] text-white">
-      <Sidebar />
+      <Sidebar activeItem={active} onSelect={setActive} />
       <div className="flex-1 flex flex-col">
-        <Topbar />
-        <main className="p-6 overflow-y-auto">
-          <Dashboard />
-        </main>
+        <Topbar lastUpdate={lastUpdate} />
+        <main className="p-6 overflow-y-auto">{renderContent()}</main>
       </div>
     </div>
   );

--- a/src/components/APICallLatencyGraph.jsx
+++ b/src/components/APICallLatencyGraph.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+
+const generatePoint = () => 200 + Math.round(Math.random() * 200);
+
+const APICallLatencyGraph = () => {
+  const [points, setPoints] = useState(() => Array.from({ length: 10 }, generatePoint));
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setPoints((prev) => [...prev.slice(1), generatePoint()]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  const height = 100;
+  const max = Math.max(...points, 400);
+  const barWidth = 30;
+
+  return (
+    <div className="bg-slate-900 p-6 rounded-2xl shadow-xl">
+      <h2 className="text-xl font-semibold mb-4">API Latency (ms)</h2>
+      <svg viewBox={`0 0 ${points.length * barWidth} ${height}`} className="w-full h-24">
+        {points.map((p, i) => (
+          <rect
+            key={i}
+            x={i * barWidth}
+            y={height - (p / max) * height}
+            width={barWidth - 2}
+            height={(p / max) * height}
+            fill="#14ffe9"
+          />
+        ))}
+      </svg>
+    </div>
+  );
+};
+
+export default APICallLatencyGraph;

--- a/src/components/APIErrorTable.jsx
+++ b/src/components/APIErrorTable.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+
+const initialRows = [
+  { endpoint: '/v1/chat', errors: 12, last: 'just now' },
+  { endpoint: '/v1/search', errors: 5, last: '1m ago' },
+  { endpoint: '/v1/completions', errors: 3, last: '2m ago' },
+];
+
+const APIErrorTable = () => {
+  const [rows, setRows] = useState(initialRows);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRows((prev) =>
+        prev.map((r) => ({
+          ...r,
+          errors: r.errors + Math.floor(Math.random() * 3),
+          last: 'just now',
+        }))
+      );
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="bg-slate-900 p-6 rounded-2xl shadow-xl">
+      <h2 className="text-xl font-semibold mb-4">API Error Table</h2>
+      <table className="w-full text-sm">
+        <thead className="text-gray-400 border-b border-gray-700">
+          <tr>
+            <th className="py-2 text-left">Endpoint</th>
+            <th>Errors</th>
+            <th>Last Error</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.endpoint} className="border-b border-gray-800">
+              <td className="py-2">{r.endpoint}</td>
+              <td>{r.errors}</td>
+              <td>{r.last}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default APIErrorTable;

--- a/src/components/APIWatcher.jsx
+++ b/src/components/APIWatcher.jsx
@@ -14,9 +14,22 @@ const APIWatcher = () => {
   const [stats, setStats] = useState(null);
 
   useEffect(() => {
-    // simulate async load
-    const timer = setTimeout(() => setStats(mockApiStats), 1000);
-    return () => clearTimeout(timer);
+    const loadTimer = setTimeout(() => setStats(mockApiStats), 1000);
+    const interval = setInterval(() => {
+      setStats((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          totalCalls: prev.totalCalls + Math.floor(Math.random() * 50),
+          errorRate: Math.max(0, +(prev.errorRate + (Math.random() - 0.5)).toFixed(1)),
+          avgLatencyMs: prev.avgLatencyMs + Math.round(Math.random() * 20 - 10),
+        };
+      });
+    }, 5000);
+    return () => {
+      clearTimeout(loadTimer);
+      clearInterval(interval);
+    };
   }, []);
 
   if (!stats) {

--- a/src/components/ARMDashboard.jsx
+++ b/src/components/ARMDashboard.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import APIWatcher from './APIWatcher';
+import AlertHub from './AlertHub';
+import APICallLatencyGraph from './APICallLatencyGraph';
+import APIErrorTable from './APIErrorTable';
+
+const ARMDashboard = () => {
+  return (
+    <div className="space-y-6">
+      <APIWatcher />
+      <AlertHub />
+      <APICallLatencyGraph />
+      <APIErrorTable />
+    </div>
+  );
+};
+
+export default ARMDashboard;

--- a/src/components/AlertHub.jsx
+++ b/src/components/AlertHub.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+
+const levels = [
+  { label: 'info', className: 'text-green-400' },
+  { label: 'warning', className: 'text-yellow-400' },
+  { label: 'critical', className: 'text-red-400' },
+];
+
+const createAlert = () => {
+  const level = levels[Math.floor(Math.random() * levels.length)];
+  return {
+    id: Date.now() + Math.random(),
+    time: new Date().toLocaleTimeString(),
+    level: level.label,
+    className: level.className,
+    message: `Mock alert ${Math.floor(Math.random() * 1000)}`,
+  };
+};
+
+const AlertHub = () => {
+  const [alerts, setAlerts] = useState(() => Array.from({ length: 3 }, createAlert));
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setAlerts((prev) => [createAlert(), ...prev.slice(0, 9)]);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="bg-slate-900 p-6 rounded-2xl shadow-xl">
+      <h2 className="text-xl font-semibold mb-4">Alert Hub</h2>
+      <ul className="space-y-1 text-sm">
+        {alerts.map((a) => (
+          <li key={a.id} className="flex justify-between border-b border-slate-700 py-1">
+            <span>{a.time}</span>
+            <span className={a.className}>{a.message}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AlertHub;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { FaChartBar, FaRobot, FaBell, FaFileAlt, FaCog } from 'react-icons/fa';
+import { FaChartBar, FaRobot, FaBell, FaFileAlt, FaCog, FaShieldAlt } from 'react-icons/fa';
 
 const items = [
   { icon: <FaChartBar />, label: 'Dashboard' },
+  { icon: <FaShieldAlt />, label: 'ARM (AI Risk Manager)' },
   { icon: <FaRobot />, label: 'AI Models' },
   { icon: <FaChartBar />, label: 'Risk Insights' },
   { icon: <FaBell />, label: 'Alerts' },


### PR DESCRIPTION
## Summary
- add ARM dashboard components and page
- update sidebar with ARM menu item
- refresh APIWatcher and new widgets every 5 seconds
- enable simple navigation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5b5ef5cc832794a4ed09d3769e0b