### PR TITLE
Add ARM management pages

### DIFF
--- a/pages/arm/api.tsx
+++ b/pages/arm/api.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import APIWatcher from '../../src/components/APIWatcher';
+import AlertHub from '../../src/components/AlertHub';
+
+const ApiRisk: React.FC = () => (
+  <div className="space-y-4">
+    <APIWatcher />
+    <AlertHub />
+  </div>
+);
+
+export default ApiRisk;

--- a/pages/arm/index.tsx
+++ b/pages/arm/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Dashboard from '../../src/components/Dashboard';
+
+const ArmOverview: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <Dashboard />
+    </div>
+  );
+};
+
+export default ArmOverview;

--- a/pages/arm/model.tsx
+++ b/pages/arm/model.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ModelStatus from '../../src/components/ModelStatus';
+
+const ModelRisk: React.FC = () => (
+  <div>
+    <ModelStatus />
+  </div>
+);
+
+export default ModelRisk;

--- a/pages/arm/prompt.tsx
+++ b/pages/arm/prompt.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import PromptMonitor from '../../src/components/PromptMonitor';
+
+const PromptRisk: React.FC = () => (
+  <div>
+    <PromptMonitor />
+  </div>
+);
+
+export default PromptRisk;

--- a/pages/arm/security.tsx
+++ b/pages/arm/security.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SecurityWatcher from '../../src/components/SecurityWatcher';
+
+const SecurityPage: React.FC = () => (
+  <div>
+    <SecurityWatcher />
+  </div>
+);
+
+export default SecurityPage;

--- a/pages/arm/traffic.tsx
+++ b/pages/arm/traffic.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import TrafficGuard from '../../src/components/TrafficGuard';
+import RateLimitTable from '../../src/components/RateLimitTable';
+
+const TrafficPage: React.FC = () => (
+  <div className="space-y-4">
+    <TrafficGuard />
+    <RateLimitTable />
+  </div>
+);
+
+export default TrafficPage;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,42 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Sidebar from './components/Sidebar';
 import Topbar from './components/Topbar';
 import Dashboard from './components/Dashboard';
+import ArmOverview from '../pages/arm';
+import ApiRisk from '../pages/arm/api';
+import TrafficPage from '../pages/arm/traffic';
+import PromptRisk from '../pages/arm/prompt';
+import ModelRisk from '../pages/arm/model';
+import SecurityPage from '../pages/arm/security';
 
 const App = () => {
+  const [page, setPage] = useState('ARM Overview');
+
+  const renderPage = () => {
+    switch (page) {
+      case 'API Risk':
+        return <ApiRisk />;
+      case 'Traffic Guard':
+        return <TrafficPage />;
+      case 'Prompt Risk':
+        return <PromptRisk />;
+      case 'Model Risk':
+        return <ModelRisk />;
+      case 'Security Watch':
+        return <SecurityPage />;
+      case 'ARM Overview':
+        return <ArmOverview />;
+      default:
+        return <Dashboard />;
+    }
+  };
+
   return (
     <div className="flex h-screen bg-[#0e1116] text-white">
-      <Sidebar />
+      <Sidebar activeItem={page} onSelect={setPage} />
       <div className="flex-1 flex flex-col">
         <Topbar />
-        <main className="p-6 overflow-y-auto">
-          <Dashboard />
-        </main>
+        <main className="p-6 overflow-y-auto">{renderPage()}</main>
       </div>
     </div>
   );

--- a/src/components/AlertHub.jsx
+++ b/src/components/AlertHub.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+const severities = ['low', 'medium', 'high'];
+
+const generateAlert = () => ({
+  id: Date.now(),
+  time: new Date().toLocaleTimeString(),
+  message: 'Mock alert message',
+  severity: severities[Math.floor(Math.random() * severities.length)],
+});
+
+const getColor = (sev) => {
+  if (sev === 'high') return 'text-red-400';
+  if (sev === 'medium') return 'text-yellow-400';
+  return 'text-blue-400';
+};
+
+const AlertHub = () => {
+  const [alerts, setAlerts] = useState([generateAlert()]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setAlerts((prev) => [generateAlert(), ...prev.slice(0, 4)]);
+    }, 1500);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="bg-[#1a1f29] p-4 rounded-xl shadow-lg w-full">
+      <h3 className="text-lg font-semibold mb-2">Alert Hub</h3>
+      <ul className="space-y-1 text-sm">
+        {alerts.map((a) => (
+          <li key={a.id} className={getColor(a.severity)}>
+            [{a.time}] {a.message} ({a.severity})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AlertHub;

--- a/src/components/PromptMonitor.jsx
+++ b/src/components/PromptMonitor.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+const generateEntry = () => ({
+  id: Date.now(),
+  prompt: 'User input example',
+  flagged: Math.random() > 0.7,
+});
+
+const PromptMonitor = () => {
+  const [entries, setEntries] = useState([generateEntry()]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setEntries((prev) => [generateEntry(), ...prev.slice(0, 4)]);
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="bg-[#1a1f29] p-4 rounded-xl shadow-lg w-full">
+      <h3 className="text-lg font-semibold mb-2">Prompt Injection Monitor</h3>
+      <table className="w-full text-sm text-left">
+        <thead className="text-gray-400 border-b border-gray-700">
+          <tr>
+            <th className="py-2">Prompt</th>
+            <th>Flagged</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((e) => (
+            <tr key={e.id} className="border-b border-gray-800">
+              <td className="py-1">{e.prompt}</td>
+              <td>{e.flagged ? 'Yes' : 'No'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default PromptMonitor;

--- a/src/components/RateLimitTable.jsx
+++ b/src/components/RateLimitTable.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+
+const initialRows = [
+  { key: 'IP 10.0.0.1', remaining: 80 },
+  { key: 'IP 10.0.0.2', remaining: 150 },
+  { key: 'IP 10.0.0.3', remaining: 20 },
+];
+
+const RateLimitTable = () => {
+  const [rows, setRows] = useState(initialRows);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setRows((prev) =>
+        prev.map((r) => ({
+          ...r,
+          remaining: Math.max(0, r.remaining - Math.floor(Math.random() * 5))),
+        }))
+      );
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="bg-[#1a1f29] p-4 rounded-xl shadow-lg w-full mt-4">
+      <h3 className="text-lg font-semibold mb-2">Rate Limit Status</h3>
+      <table className="w-full text-sm text-left">
+        <thead className="text-gray-400 border-b border-gray-700">
+          <tr>
+            <th className="py-2">Key</th>
+            <th>Remaining</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.key} className="border-b border-gray-800">
+              <td className="py-2">{r.key}</td>
+              <td>{r.remaining}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default RateLimitTable;

--- a/src/components/SecurityWatcher.jsx
+++ b/src/components/SecurityWatcher.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+const initial = [
+  { id: 1, type: 'auth fail', detail: 'User A failed login' },
+  { id: 2, type: 'token misuse', detail: 'Token XYZ used from new IP' },
+];
+
+const SecurityWatcher = () => {
+  const [logs, setLogs] = useState(initial);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const id = Date.now();
+      const type = Math.random() > 0.5 ? 'auth fail' : 'token misuse';
+      setLogs((p) => [
+        { id, type, detail: `Event ${id.toString().slice(-4)}` },
+        ...p.slice(0, 4),
+      ]);
+    }, 2500);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="bg-[#1a1f29] p-4 rounded-xl shadow-lg w-full">
+      <h3 className="text-lg font-semibold mb-2">Security Watch</h3>
+      <ul className="text-sm space-y-1">
+        {logs.map((l) => (
+          <li key={l.id}>
+            [{l.type}] {l.detail}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SecurityWatcher;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { FaChartBar, FaRobot, FaBell, FaFileAlt, FaCog } from 'react-icons/fa';
+import {
+  FaChartBar,
+  FaRobot,
+  FaBell,
+  FaFileAlt,
+  FaCog,
+  FaShieldAlt,
+} from 'react-icons/fa';
 
 const items = [
   { icon: <FaChartBar />, label: 'Dashboard' },
@@ -10,12 +17,31 @@ const items = [
   { icon: <FaCog />, label: 'Settings' },
 ];
 
+const armItems = [
+  { icon: <FaShieldAlt />, label: 'ARM Overview' },
+  { icon: <FaShieldAlt />, label: 'API Risk' },
+  { icon: <FaShieldAlt />, label: 'Traffic Guard' },
+  { icon: <FaShieldAlt />, label: 'Prompt Risk' },
+  { icon: <FaShieldAlt />, label: 'Model Risk' },
+  { icon: <FaShieldAlt />, label: 'Security Watch' },
+];
+
 const Sidebar = ({ activeItem, onSelect }) => {
   return (
     <aside className="w-64 bg-[#1a1f29] p-6 space-y-4">
       <div className="text-2xl font-bold mb-8">AuditMind</div>
       <nav className="flex flex-col space-y-4">
         {items.map((item) => (
+          <SidebarItem
+            key={item.label}
+            icon={item.icon}
+            label={item.label}
+            active={activeItem === item.label}
+            onClick={() => onSelect(item.label)}
+          />
+        ))}
+        <div className="pt-4 text-sm text-gray-400">ARM (AI Risk Manager)</div>
+        {armItems.map((item) => (
           <SidebarItem
             key={item.label}
             icon={item.icon}

--- a/src/components/TrafficGuard.jsx
+++ b/src/components/TrafficGuard.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+
+const initialData = [
+  { path: '/v1/completions', count: 1200, blocked: 12 },
+  { path: '/v1/search', count: 860, blocked: 3 },
+  { path: '/v1/chat', count: 450, blocked: 0 },
+];
+
+const TrafficGuard = () => {
+  const [data, setData] = useState(initialData);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setData((prev) =>
+        prev.map((d) => ({
+          ...d,
+          count: d.count + Math.floor(Math.random() * 10),
+          blocked: d.blocked + (Math.random() > 0.8 ? 1 : 0),
+        }))
+      );
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="bg-[#1a1f29] p-4 rounded-xl shadow-lg w-full">
+      <h3 className="text-lg font-semibold mb-2">Traffic Guard</h3>
+      <table className="w-full text-sm text-left">
+        <thead className="text-gray-400 border-b border-gray-700">
+          <tr>
+            <th className="py-2">Endpoint</th>
+            <th>Requests</th>
+            <th>Blocked</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((d) => (
+            <tr key={d.path} className="border-b border-gray-800">
+              <td className="py-2">{d.path}</td>
+              <td>{d.count}</td>
+              <td>{d.blocked}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default TrafficGuard;


### PR DESCRIPTION
## Summary
- add ARM Overview and five risk monitoring pages under `/pages/arm`
- implement AlertHub, TrafficGuard, RateLimitTable, PromptMonitor, SecurityWatcher components
- update sidebar with ARM menu
- switch displayed content based on sidebar selection

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5f175da483279683ca19d4d97c5e