### PR TITLE
Add API Manager pages and sidebar submenu

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -2,18 +2,38 @@ import React, { useState } from 'react';
 import Sidebar from './components/Sidebar';
 import Topbar from './components/Topbar';
 import Dashboard from './components/Dashboard';
+import APIMDashboard from './pages/api-manager';
+import APIRiskPage from './pages/api-manager/risk';
+import TrafficPage from './pages/api-manager/traffic';
+import TokenAbusePage from './pages/api-manager/token';
+import PromptRiskPage from './pages/api-manager/prompt';
+import SecurityWatchPage from './pages/api-manager/security';
 
 const App = () => {
   const [active, setActive] = useState('Dashboard');
   const [lastUpdate, setLastUpdate] = useState(Date.now());
 
   const renderContent = () => {
-    if (active === 'Dashboard') {
-      return <Dashboard onUpdate={() => setLastUpdate(Date.now())} />;
+    switch (active) {
+      case 'Dashboard':
+        return <Dashboard onUpdate={() => setLastUpdate(Date.now())} />;
+      case 'api-overview':
+        return <APIMDashboard />;
+      case 'api-risk':
+        return <APIRiskPage />;
+      case 'traffic-guard':
+        return <TrafficPage />;
+      case 'token-abuse':
+        return <TokenAbusePage />;
+      case 'prompt-risk':
+        return <PromptRiskPage />;
+      case 'security-watch':
+        return <SecurityWatchPage />;
+      default:
+        return (
+          <div className="p-6 text-gray-400">{active} page coming soon...</div>
+        );
     }
-    return (
-      <div className="p-6 text-gray-400">{active} page coming soon...</div>
-    );
   };
 
   return (

--- a/src/components/APICallStatsCard.jsx
+++ b/src/components/APICallStatsCard.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+
+export default function APICallStatsCard() {
+  const [stats, setStats] = useState({ calls: 0, error: 0, latency: 0 });
+
+  useEffect(() => {
+    const gen = () =>
+      setStats({
+        calls: 5000 + Math.floor(Math.random() * 1000),
+        error: (Math.random() * 5).toFixed(2),
+        latency: (100 + Math.random() * 400).toFixed(0),
+      });
+    gen();
+    const id = setInterval(gen, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="bg-slate-900 rounded p-4 shadow space-y-1 text-sm">
+      <div>Calls: {stats.calls}</div>
+      <div>Error Rate: {stats.error}%</div>
+      <div>Avg Latency: {stats.latency}ms</div>
+    </div>
+  );
+}

--- a/src/components/APIErrorTable.jsx
+++ b/src/components/APIErrorTable.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+
+const codes = [400, 401, 403, 404, 500, 502, 503];
+
+export default function APIErrorTable() {
+  const [rows, setRows] = useState([]);
+
+  useEffect(() => {
+    const gen = () => setRows(codes.map(c => ({ code: c, count: Math.floor(Math.random()*20) })));
+    gen();
+    const id = setInterval(gen, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <table className="w-full text-sm bg-slate-900 rounded">
+      <thead>
+        <tr className="text-left">
+          <th className="px-2 py-1">Status</th>
+          <th className="px-2 py-1">Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(r => (
+          <tr key={r.code} className="border-t border-slate-800">
+            <td className="px-2 py-1">{r.code}</td>
+            <td className="px-2 py-1">{r.count}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/AlertHub.jsx
+++ b/src/components/AlertHub.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+
+const samples = ['Spike detected', 'High latency', 'Unauthorized call'];
+
+export default function AlertHub() {
+  const [alerts, setAlerts] = useState([]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setAlerts(a => [samples[Math.floor(Math.random()*samples.length)], ...a].slice(0,3));
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="bg-slate-900 p-3 rounded space-y-1 text-sm">
+      {alerts.map((a,i) => <div key={i}>{a}</div>)}
+    </div>
+  );
+}

--- a/src/components/BlockedClientsList.jsx
+++ b/src/components/BlockedClientsList.jsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+
+export default function BlockedClientsList() {
+  const [clients, setClients] = useState([]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const count = Math.floor(Math.random() * 3);
+      setClients(Array.from({ length: count }, (_, i) => `client-${i + 1}`));
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <ul className="bg-slate-900 p-4 rounded space-y-1 text-sm">
+      {clients.map(c => (
+        <li key={c}>{c}</li>
+      ))}
+      {clients.length === 0 && <li>No blocked clients</li>}
+    </ul>
+  );
+}

--- a/src/components/PromptGuard.jsx
+++ b/src/components/PromptGuard.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+
+export default function PromptGuard() {
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setLogs(l => [`Injection attempt ${Date.now()}`, ...l].slice(0, 5));
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="bg-slate-900 p-4 rounded space-y-1 text-sm">
+      {logs.map((log, i) => (
+        <div key={i}>{log}</div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/RateLimitConfigPanel.jsx
+++ b/src/components/RateLimitConfigPanel.jsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+
+export default function RateLimitConfigPanel() {
+  const [limit, setLimit] = useState(1000);
+
+  return (
+    <div className="bg-slate-900 p-4 rounded space-y-2 text-sm">
+      <label>Rate Limit {limit} rpm</label>
+      <input
+        type="range"
+        min="100"
+        max="2000"
+        value={limit}
+        onChange={e => setLimit(Number(e.target.value))}
+        className="w-full"
+      />
+    </div>
+  );
+}

--- a/src/components/RateLimitTable.jsx
+++ b/src/components/RateLimitTable.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+const tokens = ['tokenA', 'tokenB', 'tokenC'];
+
+export default function RateLimitTable() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const gen = () => {
+      setData(tokens.map(t => ({
+        name: t,
+        count: Math.floor(Math.random()*100),
+        blocked: Math.random() < 0.1,
+      })));
+    };
+    gen();
+    const id = setInterval(gen, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <table className="w-full text-sm bg-slate-900 rounded">
+      <thead>
+        <tr className="text-left">
+          <th className="px-2 py-1">Token</th>
+          <th className="px-2 py-1">Requests</th>
+          <th className="px-2 py-1">Blocked</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map(r => (
+          <tr key={r.name} className="border-t border-slate-800">
+            <td className="px-2 py-1">{r.name}</td>
+            <td className="px-2 py-1">{r.count}</td>
+            <td className="px-2 py-1">{r.blocked ? 'Yes' : 'No'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/SecurityLogPanel.jsx
+++ b/src/components/SecurityLogPanel.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+
+export default function SecurityLogPanel() {
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setLogs(l => [`Failed login ${Date.now()}`, ...l].slice(0, 5));
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="bg-slate-900 p-4 rounded space-y-1 text-sm">
+      {logs.map((l, i) => (
+        <div key={i}>{l}</div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,17 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FaChartBar, FaRobot, FaBell, FaFileAlt, FaCog, FaShieldAlt } from 'react-icons/fa';
 
 const items = [
-  { icon: <FaChartBar />, label: 'Dashboard' },
-  { icon: <FaRobot />, label: 'AI Models' },
-  { icon: <FaChartBar />, label: 'Risk Insights' },
-  { icon: <FaShieldAlt />, label: 'ARM (AI Risk Manager)' },
-  { icon: <FaBell />, label: 'Alerts' },
-  { icon: <FaFileAlt />, label: 'Reports' },
-  { icon: <FaCog />, label: 'Settings' },
+  { icon: <FaChartBar />, label: 'Dashboard', key: 'Dashboard' },
+  { icon: <FaRobot />, label: 'AI Models', key: 'AI Models' },
+  { icon: <FaChartBar />, label: 'Risk Insights', key: 'Risk Insights' },
+  {
+    icon: <FaShieldAlt />,
+    label: 'API Manager',
+    key: 'API Manager',
+    children: [
+      { label: 'Overview', key: 'api-overview' },
+      { label: 'API Risk', key: 'api-risk' },
+      { label: 'Traffic Guard', key: 'traffic-guard' },
+      { label: 'Token Abuse', key: 'token-abuse' },
+      { label: 'Prompt Risk', key: 'prompt-risk' },
+      { label: 'Security Watch', key: 'security-watch' },
+    ],
+  },
+  { icon: <FaBell />, label: 'Alerts', key: 'Alerts' },
+  { icon: <FaFileAlt />, label: 'Reports', key: 'Reports' },
+  { icon: <FaCog />, label: 'Settings', key: 'Settings' },
 ];
 
 const Sidebar = ({ activeItem, onSelect }) => {
+  const [open, setOpen] = useState(true);
   return (
     <aside className="w-[240px] bg-[#1a2235] p-6 space-y-4">
       <div className="flex items-center text-2xl font-bold mb-8">
@@ -52,27 +65,51 @@ const Sidebar = ({ activeItem, onSelect }) => {
         </svg>
         <span className="ml-2">AuditMind</span>
       </div>
-      <nav className="flex flex-col space-y-4">
-        {items.map((item) => (
-          <SidebarItem
-            key={item.label}
-            icon={item.icon}
-            label={item.label}
-            active={activeItem === item.label}
-            onClick={() => onSelect(item.label)}
-          />
-        ))}
+      <nav className="flex flex-col space-y-2">
+        {items.map((item) =>
+          item.children ? (
+            <div key={item.key} className="space-y-1">
+              <SidebarItem
+                icon={item.icon}
+                label={item.label}
+                active={item.children.some((c) => c.key === activeItem)}
+                onClick={() => setOpen(!open)}
+              />
+              {open && (
+                <div className="pl-4 space-y-1">
+                  {item.children.map((ch) => (
+                    <SidebarItem
+                      key={ch.key}
+                      label={ch.label}
+                      active={activeItem === ch.key}
+                      onClick={() => onSelect(ch.key)}
+                      indent
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            <SidebarItem
+              key={item.key}
+              icon={item.icon}
+              label={item.label}
+              active={activeItem === item.key}
+              onClick={() => onSelect(item.key)}
+            />
+          )
+        )}
       </nav>
     </aside>
   );
 };
 
-const SidebarItem = ({ icon, label, active, onClick }) => (
+const SidebarItem = ({ icon, label, active, onClick, indent }) => (
   <div
     onClick={onClick}
     className={`flex items-center space-x-3 px-3 py-2 rounded-lg cursor-pointer hover:bg-[#2a2f3a] ${
       active ? 'bg-[#2a2f3a] font-semibold' : ''
-    }`}
+    } ${indent ? 'pl-5' : ''}`}
   >
     {icon}
     <span>{label}</span>

--- a/src/components/TokenAbuseTable.jsx
+++ b/src/components/TokenAbuseTable.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+export default function TokenAbuseTable() {
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const sample = Array.from({ length: 3 }, () => ({
+        token: 'tok-' + Math.floor(Math.random() * 100),
+        count: Math.floor(Math.random() * 20),
+      }));
+      setLogs(sample);
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <table className="w-full text-sm bg-slate-900 rounded">
+      <thead>
+        <tr className="text-left">
+          <th className="px-2 py-1">Token</th>
+          <th className="px-2 py-1">Abuse Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        {logs.map((l, i) => (
+          <tr key={i} className="border-t border-slate-800">
+            <td className="px-2 py-1">{l.token}</td>
+            <td className="px-2 py-1">{l.count}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/TrafficGuard.jsx
+++ b/src/components/TrafficGuard.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+
+export default function TrafficGuard() {
+  const [limit] = useState(1000);
+  const [usage, setUsage] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setUsage(Math.floor(Math.random() * limit));
+    }, 5000);
+    return () => clearInterval(id);
+  }, [limit]);
+
+  return (
+    <div className="bg-slate-900 p-4 rounded space-y-1 text-sm">
+      <div>Rate Limit: {limit} rpm</div>
+      <div>Current Usage: {usage}</div>
+    </div>
+  );
+}

--- a/src/pages/api-manager/index.jsx
+++ b/src/pages/api-manager/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import APICallStatsCard from '../../components/APICallStatsCard';
+import AlertHub from '../../components/AlertHub';
+import TrafficGuard from '../../components/TrafficGuard';
+
+export default function APIMDashboard() {
+  return (
+    <div className="p-6 space-y-6 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-3xl font-bold">🛡️ API Manager Dashboard</h1>
+      <APICallStatsCard />
+      <AlertHub />
+      <TrafficGuard />
+    </div>
+  );
+}

--- a/src/pages/api-manager/prompt.jsx
+++ b/src/pages/api-manager/prompt.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import PromptGuard from '../../components/PromptGuard';
+
+export default function PromptRiskPage() {
+  return (
+    <div className="p-6 space-y-4 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-2xl font-bold">Prompt Risk</h1>
+      <PromptGuard />
+    </div>
+  );
+}

--- a/src/pages/api-manager/risk.jsx
+++ b/src/pages/api-manager/risk.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import APICallStatsCard from '../../components/APICallStatsCard';
+import APIErrorTable from '../../components/APIErrorTable';
+
+export default function APIRiskPage() {
+  return (
+    <div className="p-6 space-y-4 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-2xl font-bold">API Risk</h1>
+      <APICallStatsCard />
+      <APIErrorTable />
+    </div>
+  );
+}

--- a/src/pages/api-manager/security.jsx
+++ b/src/pages/api-manager/security.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import SecurityLogPanel from '../../components/SecurityLogPanel';
+
+export default function SecurityWatchPage() {
+  return (
+    <div className="p-6 space-y-4 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-2xl font-bold">Security Watch</h1>
+      <SecurityLogPanel />
+    </div>
+  );
+}

--- a/src/pages/api-manager/token.jsx
+++ b/src/pages/api-manager/token.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import TokenAbuseTable from '../../components/TokenAbuseTable';
+
+export default function TokenAbusePage() {
+  return (
+    <div className="p-6 space-y-4 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-2xl font-bold">Token Abuse</h1>
+      <TokenAbuseTable />
+    </div>
+  );
+}

--- a/src/pages/api-manager/traffic.jsx
+++ b/src/pages/api-manager/traffic.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import TrafficGuard from '../../components/TrafficGuard';
+import RateLimitTable from '../../components/RateLimitTable';
+import RateLimitConfigPanel from '../../components/RateLimitConfigPanel';
+import BlockedClientsList from '../../components/BlockedClientsList';
+
+export default function TrafficPage() {
+  return (
+    <div className="p-6 space-y-4 bg-slate-950 min-h-screen text-white">
+      <h1 className="text-2xl font-bold">Traffic Guard</h1>
+      <TrafficGuard />
+      <RateLimitConfigPanel />
+      <RateLimitTable />
+      <BlockedClientsList />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API Manager sub menu in the sidebar with 6 subpages
- create API Manager dashboard and feature pages under `src/pages/api-manager`
- implement mock components for API stats, errors, traffic and security
- wire pages through the app router

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6b263de083279208fd163f2c0166