### PR TITLE
Update UI with gradient background and sidebar tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AuditMind Dashboard</title>
   </head>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,7 +47,10 @@ const App = () => {
   };
 
   return (
-    <div className="flex h-screen bg-[#131926] text-white">
+    <div
+      className="flex min-h-screen rounded-3xl text-white px-10 py-8"
+      style={{ boxShadow: '0px 8px 32px rgba(21,31,68,0.5)' }}
+    >
       <Sidebar activeItem={active} onSelect={setActive} />
       <div className="flex-1 flex flex-col items-center">
         <Topbar />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { FaChartBar, FaRobot, FaBell, FaFileAlt, FaCog, FaShieldAlt } from 'react-icons/fa';
 
 const items = [
-  { icon: <FaChartBar />, label: 'Dashboard' },
-  { icon: <FaRobot />, label: 'AI Models' },
-  { icon: <FaChartBar />, label: 'Risk Insights' },
+  { icon: <FaChartBar className="text-[22px]" />, label: 'Dashboard' },
+  { icon: <FaRobot className="text-[22px]" />, label: 'AI Models' },
+  { icon: <FaChartBar className="text-[22px]" />, label: 'Risk Insights' },
   {
-    icon: <FaShieldAlt />,
+    icon: <FaShieldAlt className="text-[22px]" />,
     label: 'API Manager',
     children: [
       { label: 'Dashboard', key: 'API Manager Dashboard' },
@@ -17,9 +17,9 @@ const items = [
       { label: 'Security Log', key: 'API Manager Security Log' },
     ],
   },
-  { icon: <FaBell />, label: 'Alerts' },
-  { icon: <FaFileAlt />, label: 'Reports' },
-  { icon: <FaCog />, label: 'Settings' },
+  { icon: <FaBell className="text-[22px]" />, label: 'Alerts' },
+  { icon: <FaFileAlt className="text-[22px]" />, label: 'Reports' },
+  { icon: <FaCog className="text-[22px]" />, label: 'Settings' },
 ];
 
 import { useState } from 'react';
@@ -35,8 +35,8 @@ const Sidebar = ({ activeItem, onSelect }) => {
     item.children && item.children.some((c) => c.key === activeItem);
 
   return (
-    <aside className="w-[240px] bg-[#1a2235] p-6 space-y-4">
-      <div className="flex items-center text-2xl font-bold mb-8">
+    <aside className="w-24 bg-[#131823] p-4 space-y-4">
+      <div className="flex items-center text-2xl font-bold mb-8 mt-10">
         <svg
           className="w-10 h-10 drop-shadow-lg"
           viewBox="0 0 56 56"
@@ -108,11 +108,11 @@ const Sidebar = ({ activeItem, onSelect }) => {
 const SidebarItem = ({ icon, label, active, onClick, small }) => (
   <div
     onClick={onClick}
-    className={`flex items-center space-x-3 px-3 py-2 rounded-lg cursor-pointer hover:bg-[#2a2f3a] ${
-      active ? 'bg-[#2a2f3a] font-semibold' : ''
+    className={`flex items-center space-x-3 px-3 py-2 rounded-lg cursor-pointer hover:bg-[#182136] ${
+      active ? 'bg-[#1c2232] text-[#8ed0ff]' : 'text-[#6b7ca6]'
     } ${small ? 'text-sm ml-4' : ''}`}
   >
-    {icon && icon}
+    <span className={`${active ? 'text-[#8ed0ff]' : 'text-[#3d5e85]'}`}>{icon}</span>
     <span>{label}</span>
   </div>
 );

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -16,10 +16,12 @@ const Topbar = ({ lastUpdate }) => {
     <div className="flex justify-between items-center p-4 border-b border-gray-700">
       <h1 className="text-2xl font-semibold">AI Risk Management Dashboard</h1>
       <div className="flex items-center gap-4">
-        <span className="text-sm text-gray-400">Updated {elapsed}s ago</span>
+        <span className="text-sm text-gray-400 ml-5">Updated {elapsed}s ago</span>
         <button
-          className="text-white text-sm px-4 py-2 rounded-lg font-medium"
-          style={{ background: 'linear-gradient(90deg,#34b4ff,#54a7f8)' }}
+          className="text-white text-sm font-medium rounded-[10px] px-[18px] py-2 shadow"
+          style={{ background: '#3350a5', boxShadow: '0 2px 12px #18316c44' }}
+          onMouseEnter={(e) => (e.currentTarget.style.background = '#517ee7')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = '#3350a5')}
         >
           Download Report
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: linear-gradient(135deg, #111623 0%, #21283a 100%);
+  color: #f2fbff;
+}


### PR DESCRIPTION
## Summary
- import Inter font and use gradient background
- wrap main layout in rounded container with shadow
- style sidebar items and resize sidebar
- adjust download button styling in topbar

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d14e7b0848327b94dccadfc0858ef